### PR TITLE
Fix DataSource Delegate of new Wildfly 9.0.1.Final

### DIFF
--- a/javamelody-core/src/main/java/net/bull/javamelody/JdbcWrapper.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/JdbcWrapper.java
@@ -490,6 +490,13 @@ public final class JdbcWrapper {
 			javaxConnectionManager = createJavaxConnectionManagerProxy(javaxConnectionManager);
 			JdbcWrapperHelper.setFieldValue(dataSource, "cm", javaxConnectionManager);
 			LOG.debug(dataSourceRewrappedMessage);
+		} else if (isWildfly9DataSource(dataSourceClassName)) {
+			Object delegateDataSource = JdbcWrapperHelper.getFieldValue(dataSource, "delegate");
+			Object javaxConnectionManager = JdbcWrapperHelper.getFieldValue(delegateDataSource,
+					"cm");
+			javaxConnectionManager = createJavaxConnectionManagerProxy(javaxConnectionManager);
+			JdbcWrapperHelper.setFieldValue(delegateDataSource, "cm", javaxConnectionManager);
+			LOG.debug(dataSourceRewrappedMessage);
 		} else if (weblogic
 				&& "weblogic.jdbc.common.internal.RmiDataSource".equals(dataSourceClassName)) {
 			// WEBLOGIC: le contexte JNDI est en lecture seule donc on modifie directement
@@ -539,6 +546,12 @@ public final class JdbcWrapper {
 				|| jboss
 				&& "org.jboss.jca.adapters.jdbc.WrapperDataSource".equals(dataSourceClassName)
 				|| glassfish && "com.sun.gjc.spi.jdbc40.DataSource40".equals(dataSourceClassName);
+	}
+
+	private boolean isWildfly9DataSource(String dataSourceClassName) {
+		return jboss
+				&& "org.jboss.as.connector.subsystems.datasources.WildFlyDataSource"
+						.equals(dataSourceClassName);
 	}
 
 	private void rewrapWebLogicDataSource(DataSource dataSource) throws IllegalAccessException {


### PR DESCRIPTION
Dans Wildfly 9.0.1.Final la DataSource qui est visible dans le JNDI est de type WildflyDataSource et fait un delegate vers la org.jboss.jca.adapters.jdbc.WrapperDataSource.

J'ai ajouté le cas qui permet de retrouver le connection manager à travers le delegate. 

Est-il possible d'intégrer ça à la prochaine version de javamelody pour supporter les stats SQL dans la version 9 de wildfly ?