### PR TITLE
Change the visibility of JpaWrapper.createEntityManagerFactoryProxy f…

### DIFF
--- a/javamelody-core/src/main/java/net/bull/javamelody/JpaWrapper.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/JpaWrapper.java
@@ -28,7 +28,7 @@ import javax.persistence.Query;
  * Cette classe est utile pour construire des proxy pour JPA.
  * @author Emeric Vernat
  */
-final class JpaWrapper {
+public final class JpaWrapper {
 	private static final boolean DISABLED = Boolean.parseBoolean(Parameters
 			.getParameter(Parameter.DISABLED));
 	private static final Counter JPA_COUNTER = MonitoringProxy.getJpaCounter();
@@ -41,7 +41,7 @@ final class JpaWrapper {
 		return JPA_COUNTER;
 	}
 
-	static EntityManagerFactory createEntityManagerFactoryProxy(
+	public static EntityManagerFactory createEntityManagerFactoryProxy(
 			final EntityManagerFactory entityManagerFactory) {
 		if (DISABLED || !JPA_COUNTER.isDisplayed()) {
 			return entityManagerFactory;


### PR DESCRIPTION
…rom package-protected to public.

By doing so, it enables users to directly create proxy of an EntityFactoryManager instance.

This change was made in order to enable the creation of a PersistenceProviderAdaptor (org.jipijapa.plugin.spi.PersistenceProviderAdaptor) in the context of a Wildfly 10 application.

The PersistenceProviderAdaptor (property "jboss.as.jpa.adapterClass") is required because if we only provide a custom PersistenceProvider ("provider" tag) that Wildfly does not support natively (see [here](https://docs.jboss.org/author/display/WFLY10/JPA+Reference+Guide#JPAReferenceGuide-Determinethepersistenceprovidermodule)), Wildfly will behave differently. 

For example, if the underlying provider (property "net.bull.javamelody.jpa.provider") is hibernate (value "org.hibernate.jpa.HibernatePersistenceProvider") then the automatic entity discovery and the  schema validation (property name="hibernate.hbm2ddl.auto" value="validate") are not performed.

To keep the same behavior, it is required to create a new PersistenceProviderAdaptor inheriting from the PersistenceProviderAdaptor of the PersistenceProvider we want to monitor and, in hibernate case, override the getBootstrap method to return our own implementation of EntityManagerFactoryBuilder (org.jipijapa.plugin.spi.EntityManagerFactoryBuilder). This new implementation needs only to inherit from EntityManagerFactoryBuilder implementation of the PersistenceProvider adaptor (in hibernate case, org.jboss.as.jpa.hibernate5.TwoPhaseBootstrapImpl) and override the "build" method to create a proxy of the EntityManagerFactory built:
```
	public EntityManagerFactory build()
	{
		return JpaWrapper.createEntityManagerFactoryProxy(super.build());
	}
```
