### PR TITLE
Fix a url filtering error encountered while monitoring  ArcGIS server

### DIFF
--- a/javamelody-core/src/main/java/net/bull/javamelody/MonitoringFilter.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/MonitoringFilter.java
@@ -198,7 +198,7 @@ public class MonitoringFilter implements Filter {
 			// on binde la requête http (utilisateur courant et requête complète) pour les derniers logs d'erreurs
 			httpRequest.setAttribute(CounterError.REQUEST_KEY, completeRequestName);
 			CounterError.bindRequest(httpRequest);
-			chain.doFilter(wrappedRequest, wrappedResponse);
+			chain.doFilter(httpRequest, httpResponse);
 			if (servletApi2 || !httpRequest.isAsyncStarted()) {
 				wrappedResponse.flushBuffer();
 			}


### PR DESCRIPTION
ArcGIS server provides administration pages to consult exposed services.
When  monitoring with basic options using javamelody, html rendered
resources won't appear correctly. Actually, they'll display a kind of
binary stuff instead of the expected html.

To fix that, I tried to chain the filter rendering using intial
HttpRequest and HttpResponse instead of the wrapped ones.

I tested on my dev environment and it seems OK.