### PR TITLE
avoid high memory consumption while log messages are too long

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 target
 plugins
+.idea
+*.iml
+*.diff
+*.out

--- a/javamelody-core/src/main/java/net/bull/javamelody/CounterError.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/CounterError.java
@@ -37,7 +37,7 @@ class CounterError implements Serializable {
 	 * Default max size of error message.
 	 */
 	public static final int DEFAULT_MESSAGE_MAX_SIZE = 1000;
-	public static final int DEFAULT_STACKTRACE_MAX_SIZE = 10000;
+	public static final int DEFAULT_STACKTRACE_MAX_SIZE = 50000;
 
 	private final long time;
 	private final String remoteUser;

--- a/javamelody-core/src/main/java/net/bull/javamelody/CounterError.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/CounterError.java
@@ -42,7 +42,13 @@ class CounterError implements Serializable {
 		super();
 		assert message != null;
 		this.time = System.currentTimeMillis();
+		if (message != null && message.length() > 1024){
+			message = message.substring(0, 1024);//avoid possible memory errors as javamelody store 100 errors in memory
+		}
 		this.message = message;
+		if (stackTrace != null && stackTrace.length() > 10000){
+			stackTrace = stackTrace.substring(0, 10000);
+		}
 		this.stackTrace = stackTrace;
 		final HttpServletRequest currentRequest = getCurrentRequest();
 		if (currentRequest == null) {

--- a/javamelody-core/src/test/java/net/bull/javamelody/CounterErrorTest.java
+++ b/javamelody-core/src/test/java/net/bull/javamelody/CounterErrorTest.java
@@ -1,0 +1,55 @@
+package net.bull.javamelody;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+
+/**
+ * Created by zvrablik on 4/22/16.
+ */
+public class CounterErrorTest {
+    @Before
+    public void setUp() {
+        Utils.initialize();
+    }
+
+    @Test
+    public void testMessageAndStackTraceSize() throws IOException {
+        String message = "aaaaaaaaaa";
+        String stackTrace = "bbbbbbbb";
+        CounterError counterError = new CounterError(message, stackTrace);
+        assertEquals(message, counterError.getMessage());
+        assertEquals(stackTrace, counterError.getStackTrace());
+    }
+
+    @Test
+    public void testMessageAndStackTraceSize4() throws IOException {
+        String message = "aaaaaaaaaa";
+        Utils.setProperty(Parameters.PARAMETER_SYSTEM_PREFIX+"log.size.message", "4");
+        Utils.setProperty(Parameters.PARAMETER_SYSTEM_PREFIX+"log.size.stacktrace", "5");
+
+        String stackTrace = "bbbbbbbb";
+        CounterError counterError = new CounterError(message, stackTrace);
+        String expectedMessage = "aaaa";
+        assertEquals(expectedMessage, counterError.getMessage());
+
+        String expectedStackTrace = "bbbbb";
+        assertEquals(expectedStackTrace, counterError.getStackTrace());
+    }
+
+    @Test
+    public void testMessageAndStackTraceSizeInvalidValues() throws IOException {
+        String message = "aaaaaaaaaa";
+        Utils.setProperty(Parameters.PARAMETER_SYSTEM_PREFIX+"log.size.message", "a4");
+        Utils.setProperty(Parameters.PARAMETER_SYSTEM_PREFIX+"log.size.stacktrace", "a5");
+
+        String stackTrace = "bbbbbbbb";
+        CounterError counterError = new CounterError(message, stackTrace);
+        assertEquals(message, counterError.getMessage());
+
+        assertEquals(stackTrace, counterError.getStackTrace());
+    }
+}


### PR DESCRIPTION
JavaMelody could cause OOME in case the log message is too big. The message length and the stacktrace length has to be truncated to avoid killing the monitored application in some cases.

Emeric,

I left there the parameters, default values are changed as you commented in the mailing list.
I think it is not neccessary to document the parameters as default values are used but I don't know anything about other users use cases and there could be valid request to get the limits higher.