### PR TITLE
Fix XSS in graph page

### DIFF
--- a/javamelody-core/src/main/java/net/bull/javamelody/HtmlCounterReport.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/HtmlCounterReport.java
@@ -417,7 +417,7 @@ class HtmlCounterReport extends HtmlAbstractReport {
 			writeln("  height = Math.round(width * initialHeight / initialWidth) - 48;");
 			// reload the images
 			// rq : on utilise des caractères unicode pour éviter des warnings
-			writeln("  document.getElementById('img').src = '?graph=" + urlEncode(graphName)
+			writeln("  document.getElementById('img').src = '?graph=" + I18N.htmlEncode(urlEncode(graphName), false)
 					+ "\\u0026width=' + width + '\\u0026height=' + height;");
 			writeln("  document.getElementById('img').style.width = '';");
 			writeln("}");


### PR DESCRIPTION
In this context graphName is rendered inside a <script></script> block, so we need to htmlEncode to avoid XSS vulnerabilities like: /monitoring?part=graph&graph=usedMemory<%2fscript><script>alert(1)<%2fscript>