### PR TITLE
createQuery() with CriteriaQuery, CriteriaUpdate, CriteriaDelete

### DIFF
--- a/javamelody-core/pom.xml
+++ b/javamelody-core/pom.xml
@@ -75,6 +75,12 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.hibernate.javax.persistence</groupId>
+			<artifactId>hibernate-jpa-2.1-api</artifactId>
+			<version>1.0.0.Final</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
 			<groupId>com.sun.faces</groupId>
 			<artifactId>jsf-impl</artifactId>
 			<version>2.1.5</version>
@@ -192,7 +198,7 @@
 			<version>7.0.27</version>
 			<optional>true</optional>
 		</dependency>
-		<!-- Dépendance optionnelle spring aop (qui inclus spring core, spring 
+		<!-- Dépendance optionnelle spring aop (qui inclus spring core, spring
 			beans, aop alliance et commons-logging) -->
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -283,8 +289,8 @@
 			<resource>
 				<directory>${project.basedir}/src/main/resources</directory>
 			</resource>
-			<!-- uniquement pour inclure les fichiers de licence et user_guide dans 
-				le jar produit par maven (celui qui contient pom.properties et pom.xml avec 
+			<!-- uniquement pour inclure les fichiers de licence et user_guide dans
+				le jar produit par maven (celui qui contient pom.properties et pom.xml avec
 				la version) -->
 			<resource>
 				<directory>${project.basedir}</directory>
@@ -310,7 +316,7 @@
 					<testCompilerArgument>-XDignore.symbol.file=true -Xlint</testCompilerArgument>
 				</configuration>
 			</plugin>
-			<!-- pour produire un jar lors du goal package comme celui produit par 
+			<!-- pour produire un jar lors du goal package comme celui produit par
 				ant mais avec pom.properties et pom.xml pour publication dans un repository -->
 			<plugin>
 				<artifactId>maven-jar-plugin</artifactId>

--- a/javamelody-core/src/main/java/net/bull/javamelody/JpaPersistence.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/JpaPersistence.java
@@ -247,4 +247,20 @@ public class JpaPersistence implements PersistenceProvider {
 			return method.invoke(info, args);
 		}
 	}
+
+	/**
+	 * @since jpa2.1
+	 */
+	//@Override
+	public void generateSchema(PersistenceUnitInfo info, Map map) {
+		delegate.generateSchema(info, map);
+	}
+
+	/**
+	 * @since jpa2.1
+	 */
+	//@Override
+	public boolean generateSchema(String persistenceUnitName, Map map) {
+		return delegate.generateSchema(persistenceUnitName, map);
+	}
 }

--- a/javamelody-core/src/main/java/net/bull/javamelody/Parameters.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/Parameters.java
@@ -442,10 +442,16 @@ final class Parameters {
 		if (result != null) {
 			return result;
 		}
+
 		if (servletContext != null) {
-			result = servletContext.getInitParameter(globalName);
-			if (result != null) {
-				return result;
+			try {
+				result = servletContext.getInitParameter(globalName);
+				if (result != null) {
+					return result;
+				}
+			} catch (NullPointerException ignored) {
+				// if servletContext is just a proxy, it is allways != null
+				// but it might not have been initialized
 			}
 			// issue 463: in a ServletContextListener, it's also possible to call servletContext.setAttribute("javamelody.log", "true"); for example
 			final Object attribute = servletContext.getAttribute(globalName);


### PR DESCRIPTION
Hi,

Currently, JavaMelody does not handle EntityManager.createQuery(CriteriaQuery) well:
The generated monitor name is unique per Query Instance and does contain the Object instance number.
Since we are generating lots of queries dynamically, we get *lots* of monitors for a specific statement that only ever get used once.

The changes in JpaWrapper do generate a better name for the monitor by inspecting the current stack trace an retrieving the first Method-Name that is not JavaMelody or a Proxy class (best effort here).

Also: bump to JPA 2.1
Also: on Wildfly, the ServletContext used for initialization (Parameters.java) is just a Proxy and the == null check never fails.

Sorry for bad code indentation, I could not get my IDE to do your style :(