### PR TITLE
Extend JPA Naming strategy for JPA provider internal calls

### DIFF
--- a/javamelody-core/src/main/java/net/bull/javamelody/JpaDefaultNamingStrategy.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/JpaDefaultNamingStrategy.java
@@ -19,6 +19,8 @@ package net.bull.javamelody;
 
 import java.lang.reflect.Method;
 
+import javax.persistence.Query;
+
 /**
  * Default naming strategy.
  * @author Christoph Linder
@@ -51,6 +53,12 @@ public class JpaDefaultNamingStrategy implements JpaNamingStrategy {
 		default:
 			return getOtherRequestName(javaMethod, args);
 		}
+	}
+
+	@Override
+	public String getCreateQueryRequestName(Query query, JpaMethod jpaMethod, Method javaMethod, Object[] args) {
+		// The default naming strategy does not need the query
+		return getRequestName(jpaMethod, javaMethod, args);
 	}
 
 	protected String getOtherRequestName(Method javaMethod, Object[] args) {

--- a/javamelody-core/src/main/java/net/bull/javamelody/JpaNamingStrategy.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/JpaNamingStrategy.java
@@ -20,6 +20,7 @@ package net.bull.javamelody;
 import java.lang.reflect.Method;
 
 import javax.persistence.EntityManager;
+import javax.persistence.Query;
 
 /**
  * Interface to implement jpa method to request name conversion.
@@ -29,6 +30,25 @@ import javax.persistence.EntityManager;
 public interface JpaNamingStrategy {
 
 	/**
+	 * Build the request name for all EntityManager.create*Query() methods.
+	 *
+	 * Implementors must calculate a nonnull String that will get displayed in the JPA section.
+	 *
+	 * The implementing class <b>must</b> habe a public no-args constructor.
+	 *
+	 * @param query The {@link Query} created by the current invocation of EntityManager.create*Query().
+	 * @param jpaMethod A normalization of the method that got called on the {@link EntityManager}.
+	 * 					Corresponds with param javaMethod.
+	 * @param javaMethod The method that got called on the {@link EntityManager}.
+	 * 					 Corresponds with param jpaMethod.
+	 * @param args Nullable, the arguments for javaMethod
+	 * @return a non-null String that represents the request name of the JPA-Counter.
+	 */
+	String getCreateQueryRequestName(Query query, JpaMethod jpaMethod, Method javaMethod, Object[] args);
+
+	/**
+	 * Build the request name for all other (i.E.: not EntityManager.create*Query()) methods.
+
 	 * Implementors must calculate a nonnull String that will get displayed in the JPA section.
 	 *
 	 * The implementing class <b>must</b> habe a public no-args constructor.


### PR DESCRIPTION
Hi

In #563 you mentioned an alternative way of retrieving the request name (i.E.: query string) via JPA-provider native calls (https://antoniogoncalves.org/2012/05/24/how-to-get-the-jpqlsql-string-from-a-criteriaquery-in-jpa/)

I did some fiddling with this. Unfortunately, this would require a change to the new JPA Naming Strategy API: the naming strategy must have access to the javax.persistence.Query instance.
