### PR TITLE
Change className check for Ehcache27 because Liferay Portal version 7…

### DIFF
--- a/javamelody-core/src/main/java/net/bull/javamelody/CacheInformations.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/CacheInformations.java
@@ -177,7 +177,7 @@ class CacheInformations implements Serializable {
 	private static boolean isEhcache27() {
 		try {
 			// ce Class.forName est nécessaire sur le serveur de collecte
-			Class.forName("net.sf.ehcache.statistics.StatisticsGateway");
+			Class.forName("net.sf.ehcache.config.TerracottaConfiguration");
 			return true;
 		} catch (final ClassNotFoundException e) {
 			return false;


### PR DESCRIPTION
….0 doesn't export the package net.sf.ehcache.statistics