### PR TITLE
hide property-values in the JVM-Information details

### DIFF
--- a/javamelody-core/src/main/java/net/bull/javamelody/Parameter.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/Parameter.java
@@ -197,6 +197,16 @@ public enum Parameter {
 	SYSTEM_ACTIONS_ENABLED("system-actions-enabled"),
 
 	/**
+	 * Hide passwords in JVM Property values ( default not set).
+	 * With a given a JVM_HIDE_PROPERTY_VALUE_REGEXP like ".*pass.*"
+	 * this converts JVM-Properties from
+	 * -Dsaml.password=secret
+	 * to
+	 * -Dsaml.password=**********
+	 */
+	JVM_HIDE_PROPERTY_VALUE_REGEXP("jvm-hide-property-value-regexp"),
+
+	/**
 	 * Active la protection contre CSRF (false par défaut).
 	 */
 	CSRF_PROTECTION_ENABLED("csrf-protection-enabled"),

--- a/javamelody-core/src/main/java/net/bull/javamelody/internal/common/Parameters.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/internal/common/Parameters.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.TreeMap;
+import java.util.regex.Pattern;
 
 import javax.servlet.FilterConfig;
 import javax.servlet.ServletContext;
@@ -330,6 +331,15 @@ public final class Parameters {
 	public static boolean isSystemActionsEnabled() {
 		final String parameter = Parameter.SYSTEM_ACTIONS_ENABLED.getValue();
 		return parameter == null || Boolean.parseBoolean(parameter);
+	}
+
+	/**
+	 * Pattern for JVM-Property value shadowing
+	 * @return Pattern or null
+	 */
+	public static Pattern getJvmHidePropertyValuesRegexp() {
+		final String parameter = Parameter.JVM_HIDE_PROPERTY_VALUE_REGEXP.getValue();
+		return parameter == null ? null :Pattern.compile(parameter);
 	}
 
 	public static boolean isPdfEnabled() {

--- a/javamelody-core/src/main/java/net/bull/javamelody/internal/model/JavaInformations.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/internal/model/JavaInformations.java
@@ -33,6 +33,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import javax.servlet.ServletContext;
 import javax.sql.DataSource;
@@ -302,13 +303,25 @@ public class JavaInformations implements Serializable { // NOPMD
 
 	private static String buildJvmArguments() {
 		final StringBuilder jvmArgs = new StringBuilder();
+		final Pattern jvmHidePropertyValuesRegexp = Parameters.getJvmHidePropertyValuesRegexp();
 		for (final String jvmArg : ManagementFactory.getRuntimeMXBean().getInputArguments()) {
-			jvmArgs.append(jvmArg).append('\n');
+			if(jvmHidePropertyValuesRegexp != null && jvmHidePropertyValuesRegexp.matcher(jvmArg).matches()){
+				jvmArgs.append(hideJvmPropertyValue(jvmArg)).append('\n');
+			}else {
+				jvmArgs.append(jvmArg).append('\n');
+			}
 		}
 		if (jvmArgs.length() > 0) {
 			jvmArgs.deleteCharAt(jvmArgs.length() - 1);
 		}
 		return jvmArgs.toString();
+	}
+
+	private static String hideJvmPropertyValue(final String jvmArg){
+		if(jvmArg.contains("=")){
+			return jvmArg.substring(0,jvmArg.indexOf("=") +1 ) +"**********";
+		}
+		return jvmArg;
 	}
 
 	public static List<ThreadInformations> buildThreadInformationsList() {

--- a/javamelody-core/src/test/java/net/bull/javamelody/TestParameters.java
+++ b/javamelody-core/src/test/java/net/bull/javamelody/TestParameters.java
@@ -48,6 +48,7 @@ import net.bull.javamelody.internal.model.TransportFormat;
  * @author Emeric Vernat
  */
 public class TestParameters {
+
 	private static void setProperty(Parameter parameter, String value) {
 		Utils.setProperty(parameter, value);
 	}
@@ -242,5 +243,14 @@ public class TestParameters {
 		assertFalse("isCounterHidden", Parameters.isCounterHidden("http"));
 		setProperty(Parameter.DISPLAYED_COUNTERS, "sql");
 		assertTrue("isCounterHidden", Parameters.isCounterHidden("http"));
+	}
+
+
+	@Test
+	public void getJvmHidePropertyValuesRegexp(){
+		setProperty(Parameter.JVM_HIDE_PROPERTY_VALUE_REGEXP, null);
+		assertNull("jvmHidePropertyValues", Parameters.getJvmHidePropertyValuesRegexp());
+		setProperty(Parameter.JVM_HIDE_PROPERTY_VALUE_REGEXP, ".*pass.*");
+		assertNotNull("jvmHidePropertyValue regexp not found", Parameters.getJvmHidePropertyValuesRegexp());
 	}
 }


### PR DESCRIPTION
Added a method to hide property values in the JVM Information page
- configured via init-param you can specify a regexp for shadowing passwords 