### PR TITLE
Added support for parameter "mail-subject-prefix". It can be used to …

### DIFF
--- a/javamelody-core/src/main/java/net/bull/javamelody/Parameter.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/Parameter.java
@@ -258,6 +258,14 @@ public enum Parameter {
 	 * pour l'envoi par mail de rapport de hebdomadaire (null par défaut).
 	 */
 	ADMIN_EMAILS("admin-emails"),
+	
+	/**
+	 * Used to specify prefix of the subject of the email notifications sent out by Javamelody<br>
+	 * Supports one argumentindex {0} which will be replaced by application name at the runtime.<br>
+	 * For e.g. : Production environment JavaMelody Reports for {0}.<br>
+	 * If missing, internationalized value against key "Monitoring_sur" is used.
+	 */
+	MAIL_SUBJECT_PREFIX("mail-subject-prefix"),
 
 	/**
 	 * Liste des périodes d'envoi des mails séparées par des virgules

--- a/javamelody-core/src/main/java/net/bull/javamelody/internal/web/MailReport.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/internal/web/MailReport.java
@@ -21,6 +21,7 @@ import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
+import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
@@ -154,8 +155,15 @@ public class MailReport {
 				output.close();
 			}
 
-			final String subject = I18N.getFormattedString("Monitoring_sur",
-					collector.getApplication()) + " - " + period.getLabel();
+			String subject = null;			
+			final String subjectPrefixParameter = Parameters.getParameterValue(Parameter.MAIL_SUBJECT_PREFIX);
+			if (subjectPrefixParameter != null) {
+				subject = MessageFormat.format(subjectPrefixParameter, collector.getApplication());
+			} else {
+				subject = I18N.getFormattedString("Monitoring_sur", collector.getApplication());
+			}			
+			subject +=" - " + period.getLabel();
+			
 			final Mailer mailer = new Mailer(Parameter.MAIL_SESSION.getValue());
 			final String adminEmails = Parameter.ADMIN_EMAILS.getValue();
 			mailer.send(adminEmails, subject, "", Collections.singletonList(tmpFile), false);


### PR DESCRIPTION
…configure prefix of email notification instead of using the value of key "Messages_sur". It has support for 1 argument index {0} which is replaced by application name.