### PR TITLE
Add encoding response to request

### DIFF
--- a/javamelody-core/src/main/java/net/bull/javamelody/internal/web/FilterServletResponseWrapper.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/internal/web/FilterServletResponseWrapper.java
@@ -42,6 +42,7 @@ abstract class FilterServletResponseWrapper extends HttpServletResponseWrapper {
 	FilterServletResponseWrapper(HttpServletResponse response) {
 		super(response);
 		assert response != null;
+		setCharacterEncoding(response.getCharacterEncoding());
 	}
 
 	HttpServletResponse getHttpServletResponse() {


### PR DESCRIPTION
The encoding request/reponse is not the same. If a request with a particular encoding, Javamelody broke encoding.