### PR TITLE
Extend monioring URL detection to allow custom prefixes

### DIFF
--- a/javamelody-core/src/main/java/net/bull/javamelody/MonitoringFilter.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/MonitoringFilter.java
@@ -202,7 +202,7 @@ public class MonitoringFilter implements Filter {
 		final HttpServletRequest httpRequest = (HttpServletRequest) request;
 		final HttpServletResponse httpResponse = (HttpServletResponse) response;
 
-		if (httpRequest.getRequestURI().equals(getMonitoringUrl(httpRequest))) {
+		if (httpRequest.getRequestURI().endsWith(getMonitoringUrl(httpRequest))) {
 			doMonitoring(httpRequest, httpResponse);
 			return;
 		}

--- a/javamelody-core/src/main/java/net/bull/javamelody/MonitoringFilter.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/MonitoringFilter.java
@@ -202,7 +202,9 @@ public class MonitoringFilter implements Filter {
 		final HttpServletRequest httpRequest = (HttpServletRequest) request;
 		final HttpServletResponse httpResponse = (HttpServletResponse) response;
 
-		if (httpRequest.getRequestURI().endsWith(getMonitoringUrl(httpRequest))) {
+		if (httpRequest.getRequestURI().equals(getMonitoringUrl(httpRequest))
+		    || (Parameters.getMonitoringPathAuthenticated() != null
+			&& httpRequest.getRequestURI().equals(getMonitoringPathAuthenticated(httpRequest)))) {
 			doMonitoring(httpRequest, httpResponse);
 			return;
 		}
@@ -347,6 +349,13 @@ public class MonitoringFilter implements Filter {
 			monitoringUrl = httpRequest.getContextPath() + Parameters.getMonitoringPath();
 		}
 		return monitoringUrl;
+	}
+
+	protected final String getMonitoringPathAuthenticated(HttpServletRequest httpRequest) {
+	        if (Parameters.getMonitoringPathAuthenticated() == null) {
+		    return null;
+	        }
+		return httpRequest.getContextPath() + Parameters.getMonitoringPathAuthenticated();
 	}
 
 	private void putUserInfoInSession(HttpServletRequest httpRequest) {

--- a/javamelody-core/src/main/java/net/bull/javamelody/Parameter.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/Parameter.java
@@ -291,6 +291,11 @@ public enum Parameter {
 	MONITORING_PATH("monitoring-path"),
 
 	/**
+	 * URL du rapport de monitoring alternative (null par défaut).
+	 */
+	MONITORING_PATH_AUTHENTICATED("monitoring-path-authenticated"),
+
+	/**
 	 * Identifiant de suivi google analytics s'il y a lieu (désactivé par défaut).
 	 */
 	ANALYTICS_ID("analytics-id"),

--- a/javamelody-core/src/main/java/net/bull/javamelody/internal/common/Parameters.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/internal/common/Parameters.java
@@ -232,6 +232,10 @@ public final class Parameters {
 		return parameterValue;
 	}
 
+	public static String getMonitoringPathAuthenticated() {
+		return Parameter.MONITORING_PATH_AUTHENTICATED.getValue();
+	}
+
 	/**
 	 * @return nom réseau de la machine
 	 */


### PR DESCRIPTION
In Gerrit Code Review auth requests are prepended with "/a" prefix.
Extend the comparisson for monitoring URI detection to allow custom
prefixes and only require that the URL is ending with pre-defined
monitoring path.

This is need to fix Prometheus scraping from Gerrit, while allowing
the authentication machinery to work as expected:

  curl -u user http://gerrit/a/monitoring?format=prometheus