### PR TITLE
replace monitoring-spring-aspectj.xml with monitoring-spring-aop.xml in order to remove AspectJ dependencies

### DIFF
--- a/javamelody-core/src/main/resources/net/bull/javamelody/monitoring-spring-aop.xml
+++ b/javamelody-core/src/main/resources/net/bull/javamelody/monitoring-spring-aop.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+            http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+
+	<bean id="autoProxyCreator"  class="org.springframework.aop.framework.autoproxy.DefaultAdvisorAutoProxyCreator"  >
+    <property name="proxyTargetClass" value="true"/>
+  </bean>
+
+
+  <bean id="monitoringAdvice" class="net.bull.javamelody.MonitoringSpringInterceptor" />
+
+  <bean id="monitoringPointcut" class="net.bull.javamelody.MonitoredWithAnnotationPointcut" />
+  <bean id="monitoringAsyncAndScheduledPointcut" class="net.bull.javamelody.MonitoredSpringAsyncAndScheduledPointcut" />
+  <bean id="monitoringControllerAndServicePointcut" class="net.bull.javamelody.MonitoredSpringControllerAndServicePointcut" />
+
+  <bean id="monitoringPointcutAdvisor" class="org.springframework.aop.support.DefaultPointcutAdvisor">
+    <property name="advice" ref="monitoringAdvice"/>
+    <property name="pointcut" ref="monitoringPointcut" />
+  </bean>
+
+  <bean id="monitoringAsyncAndScheduledAdvisor" class="org.springframework.aop.support.DefaultPointcutAdvisor">
+    <property name="advice" ref="monitoringAdvice"/>
+    <property name="pointcut" ref="monitoringAsyncAndScheduledPointcut" />
+  </bean>
+
+  <bean id="monitoringControllerAndServiceAdvisor" class="org.springframework.aop.support.DefaultPointcutAdvisor">
+    <property name="advice" ref="monitoringAdvice"/>
+    <property name="pointcut" ref="monitoringControllerAndServicePointcut" />
+  </bean>
+
+
+
+	<bean id="springDataSourceBeanPostProcessor" class="net.bull.javamelody.SpringDataSourceBeanPostProcessor">
+		<!--
+		<property name="excludedDatasources">
+			<set>
+				<value>excludedDataSourceName</value>
+			</set>
+		</property>
+		-->
+ 	</bean>
+
+	<!--
+ 	<bean id="wrappedDataSource" class="net.bull.javamelody.SpringDataSourceFactoryBean">
+		<property name="targetName" value="targetDataSource" />
+	</bean>
+	-->
+
+	<bean id="springRestTemplateBeanPostProcessor" class="net.bull.javamelody.SpringRestTemplateBeanPostProcessor" />
+
+ 	<bean id="springMongoDbFactoryBeanPostProcessor" class="net.bull.javamelody.SpringMongoDbFactoryBeanPostProcessor" />
+
+	<bean id="javamelodySpringContext" class="net.bull.javamelody.SpringContext" />
+</beans>


### PR DESCRIPTION
In our commercial application we can't use AspectJ because of its license, so i added the file monitoring-spring-aop.xml with the same functionality, but without the AspectJ specific depenencies. I think the monitoring-spring-aspectj.xml can be safely removed from the repository.