### PR TITLE
Hide Database Credentials by default

### DIFF
--- a/javamelody-core/src/main/java/net/bull/javamelody/Parameter.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/Parameter.java
@@ -392,7 +392,13 @@ public enum Parameter {
 	 * API key of the <a href='https://www.datadoghq.com/'>Datadog</a> to send metrics,
 	 * for example: 9775a026f1ca7d1c6c5af9d94d9595a4 (null by default).
 	 */
-	DATADOG_API_KEY("datadog-api-key");
+	DATADOG_API_KEY("datadog-api-key"),
+
+	/**
+	 * Inclure des détails sensibles tels que le mot de passe de la base de données,
+	 * les informations de thread et les informations de cache (null par défaut).
+	 */
+	INCLUDE_SENSITIVE_DETAILS("include-sensitive-details");
 
 	private final String code;
 

--- a/javamelody-core/src/main/java/net/bull/javamelody/internal/common/Parameters.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/internal/common/Parameters.java
@@ -406,6 +406,15 @@ public final class Parameters {
 		final String parameter = Parameter.SYSTEM_ACTIONS_ENABLED.getValue();
 		return parameter == null || Boolean.parseBoolean(parameter);
 	}
+	/**
+	 * Booléen selon que le paramètre include-sensitive-details vaut true.
+	 * (le retour par défaut est faux)
+	 * @return boolean
+	 */
+	public static boolean isSensitiveDetailsEnabled() {
+		final String parameter = Parameter.INCLUDE_SENSITIVE_DETAILS.getValue();
+		return parameter != null && Boolean.parseBoolean(parameter);
+	}
 
 	public static boolean isPdfEnabled() {
 		return PDF_ENABLED;

--- a/javamelody-core/src/main/java/net/bull/javamelody/internal/model/JavaInformations.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/internal/model/JavaInformations.java
@@ -638,6 +638,9 @@ public class JavaInformations implements Serializable { // NOPMD
 	}
 
 	public List<ThreadInformations> getThreadInformationsList() {
+		if (null == threadInformationsList) {
+			return Collections.emptyList();
+		}
 		// on trie sur demande (si affichage)
 		final List<ThreadInformations> result = new ArrayList<ThreadInformations>(
 				threadInformationsList);
@@ -689,10 +692,12 @@ public class JavaInformations implements Serializable { // NOPMD
 	}
 
 	public boolean isStackTraceEnabled() {
-		for (final ThreadInformations threadInformations : threadInformationsList) {
-			final List<StackTraceElement> stackTrace = threadInformations.getStackTrace();
-			if (stackTrace != null && !stackTrace.isEmpty()) {
-				return true;
+		if (null != threadInformationsList) {
+			for (final ThreadInformations threadInformations : threadInformationsList) {
+				final List<StackTraceElement> stackTrace = threadInformations.getStackTrace();
+				if (stackTrace != null && !stackTrace.isEmpty()) {
+					return true;
+				}
 			}
 		}
 		return false;

--- a/javamelody-core/src/main/java/net/bull/javamelody/internal/web/MonitoringController.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/internal/web/MonitoringController.java
@@ -17,6 +17,8 @@
  */
 package net.bull.javamelody.internal.web; // NOPMD
 
+import static net.bull.javamelody.internal.common.Parameters.isSensitiveDetailsEnabled;
+
 import java.io.BufferedInputStream;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -155,7 +157,7 @@ public class MonitoringController {
 		// pour avoir des informations à jour
 		final JavaInformations javaInformations;
 		if (isJavaInformationsNeeded(httpRequest)) {
-			javaInformations = new JavaInformations(servletContext, true);
+			javaInformations = new JavaInformations(servletContext, isSensitiveDetailsEnabled());
 		} else {
 			javaInformations = null;
 		}


### PR DESCRIPTION
Add Parameter INCLUDE_SENSITIVE_DETAILS to control showing sensitive information inside System Details. Default to false for best security practice. [fixes #920]