### PR TITLE
Finish Java 1.7 updates

### DIFF
--- a/javamelody-objectfactory/pom.xml
+++ b/javamelody-objectfactory/pom.xml
@@ -9,8 +9,8 @@
 	<description>Objectfactory for Glassfish V3</description>
 	<url>https://github.com/javamelody/javamelody/wiki/UserGuideAdvanced#monitoring-of-sql-requests-and-of-jdbc-connections-in-glassfish-v3</url>
 	<properties>
-		<maven.compiler.source>1.6</maven.compiler.source>
-		<maven.compiler.target>1.6</maven.compiler.target>
+		<maven.compiler.source>1.7</maven.compiler.source>
+		<maven.compiler.target>1.7</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 </project>

--- a/javamelody-test-webapp/pom.xml
+++ b/javamelody-test-webapp/pom.xml
@@ -233,6 +233,8 @@
 	</dependencies>
 
 	<properties>
+		<maven.compiler.source>1.7</maven.compiler.source>
+		<maven.compiler.target>1.7</maven.compiler.target>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>


### PR DESCRIPTION
Brings `javamelody-objectfactory` and `javamelody-test-webapp` into alignment with the dropping of Java 1.6 support in commit e12d9c78d152229c976a91c7bf75bec0f45459b0

Fixes build failures in Travis CI