### PR TITLE
New parameter statsd-prefix with the default value of `javamelody.context.host.`

### DIFF
--- a/javamelody-core/src/main/java/net/bull/javamelody/Parameter.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/Parameter.java
@@ -373,8 +373,7 @@ public enum Parameter {
 
 	/**
 	 * Prefix of metrics that are sent to the <a href='https://github.com/etsy/statsd'>StatsD</a> server.
-	 * Supports a few macros: ${context} is replaced by the application context, ${host} is replaced by the
-	 * host name. Default value is "javamelody.${context}.${host}."
+	 * Default value is "javamelody.context.host." where context and host gets replaced by the actual values.
 	 */
 	STATSD_PREFIX("statsd-prefix"),
 
@@ -419,19 +418,6 @@ public enum Parameter {
 	 */
 	public String getValue() {
 		return Parameters.getParameterValue(this);
-	}
-
-	/**
-	 *
-	 * @param defaultValue
-	 * @return value of the parameter or the default value
-	 */
-	public String getValueOrDefault(String defaultValue) {
-		String value = getValue();
-		if (value != null) {
-			return value;
-		}
-		return defaultValue;
 	}
 
 	/**

--- a/javamelody-core/src/main/java/net/bull/javamelody/Parameter.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/Parameter.java
@@ -372,6 +372,11 @@ public enum Parameter {
 	STATSD_ADDRESS("statsd-address"),
 
 	/**
+	 * Use `javamelody.metricName` instead of `javameloady.context.hostName.metricName`. False by default.
+	 */
+	STATSD_SHORT_METRIC_NAME("statsd-short-metric-name"),
+
+	/**
 	 * Namespace to use in <a href='https://aws.amazon.com/cloudwatch/'>AWS CloudWatch</a> to send metrics,
 	 * for example "MyCompany/MyAppDomain" (null by default).
 	 */

--- a/javamelody-core/src/main/java/net/bull/javamelody/Parameter.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/Parameter.java
@@ -374,7 +374,7 @@ public enum Parameter {
 	/**
 	 * Use `javamelody.metricName` instead of `javameloady.context.hostName.metricName`. False by default.
 	 */
-	STATSD_SHORT_METRIC_NAME("statsd-short-metric-name"),
+	STATSD_PREFIX("statsd-prefix"),
 
 	/**
 	 * Namespace to use in <a href='https://aws.amazon.com/cloudwatch/'>AWS CloudWatch</a> to send metrics,
@@ -417,6 +417,19 @@ public enum Parameter {
 	 */
 	public String getValue() {
 		return Parameters.getParameterValue(this);
+	}
+
+	/**
+	 *
+	 * @param defaultValue
+	 * @return value of the parameter or the default value
+	 */
+	public String getValueOrDefault(String defaultValue) {
+		String value = getValue();
+		if (value != null) {
+			return value;
+		}
+		return defaultValue;
 	}
 
 	/**

--- a/javamelody-core/src/main/java/net/bull/javamelody/Parameter.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/Parameter.java
@@ -372,7 +372,9 @@ public enum Parameter {
 	STATSD_ADDRESS("statsd-address"),
 
 	/**
-	 * Use `javamelody.metricName` instead of `javameloady.context.hostName.metricName`. False by default.
+	 * Prefix of metrics that are sent to the <a href='https://github.com/etsy/statsd'>StatsD</a> server.
+	 * Supports a few macros: ${context} is replaced by the application context, ${host} is replaced by the
+	 * host name. Default value is "javamelody.${context}.${host}."
 	 */
 	STATSD_PREFIX("statsd-prefix"),
 

--- a/javamelody-core/src/main/java/net/bull/javamelody/internal/publish/Statsd.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/internal/publish/Statsd.java
@@ -63,7 +63,6 @@ class Statsd extends MetricsPublisher {
 
 	static Statsd getInstance(String contextPath, String hostName) {
 		final String statsdAddress = Parameter.STATSD_ADDRESS.getValue();
-		final boolean shortMetricName = Parameter.STATSD_SHORT_METRIC_NAME.getValueAsBoolean();
 		if (statsdAddress != null) {
 			assert contextPath != null;
 			assert hostName != null;
@@ -79,14 +78,14 @@ class Statsd extends MetricsPublisher {
 				port = DEFAULT_STATSD_PORT;
 			}
 
-			String prefix = "javamelody.";
-			if (!shortMetricName) {
-				// contextPath est du genre "/testapp"
-				// hostName est du genre "www.host.com"
-				prefix += contextPath.replace("/", "") + '.' + hostName + '.';
-			}
+			String statsdPrefix = Parameter.STATSD_PREFIX.getValueOrDefault("javamelody.${context}.${host}.");
+			// contextPath est du genre "/testapp"
+			// hostName est du genre "www.host.com"
+			statsdPrefix = statsdPrefix.replace("${context}", contextPath.replace("/", "")).
+					replace("${host}", hostName);
+
 			try {
-				return new Statsd(InetAddress.getByName(address), port, prefix);
+				return new Statsd(InetAddress.getByName(address), port, statsdPrefix);
 			} catch (final UnknownHostException e) {
 				throw new IllegalArgumentException("Invalid host: " + address, e);
 			}
@@ -140,5 +139,9 @@ class Statsd extends MetricsPublisher {
 	@Override
 	public void stop() {
 		// nothing
+	}
+
+	public String getPrefix() {
+		return prefix;
 	}
 }

--- a/javamelody-core/src/main/java/net/bull/javamelody/internal/publish/Statsd.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/internal/publish/Statsd.java
@@ -63,6 +63,7 @@ class Statsd extends MetricsPublisher {
 
 	static Statsd getInstance(String contextPath, String hostName) {
 		final String statsdAddress = Parameter.STATSD_ADDRESS.getValue();
+		final boolean shortMetricName = Parameter.STATSD_SHORT_METRIC_NAME.getValueAsBoolean();
 		if (statsdAddress != null) {
 			assert contextPath != null;
 			assert hostName != null;
@@ -77,10 +78,13 @@ class Statsd extends MetricsPublisher {
 				address = statsdAddress;
 				port = DEFAULT_STATSD_PORT;
 			}
-			// contextPath est du genre "/testapp"
-			// hostName est du genre "www.host.com"
-			final String prefix = "javamelody." + contextPath.replace("/", "") + '.' + hostName
-					+ '.';
+
+			String prefix = "javamelody.";
+			if (!shortMetricName) {
+				// contextPath est du genre "/testapp"
+				// hostName est du genre "www.host.com"
+				prefix += contextPath.replace("/", "") + '.' + hostName + '.';
+			}
 			try {
 				return new Statsd(InetAddress.getByName(address), port, prefix);
 			} catch (final UnknownHostException e) {

--- a/javamelody-core/src/main/java/net/bull/javamelody/internal/publish/Statsd.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/internal/publish/Statsd.java
@@ -78,11 +78,12 @@ class Statsd extends MetricsPublisher {
 				port = DEFAULT_STATSD_PORT;
 			}
 
-			String statsdPrefix = Parameter.STATSD_PREFIX.getValueOrDefault("javamelody.${context}.${host}.");
-			// contextPath est du genre "/testapp"
-			// hostName est du genre "www.host.com"
-			statsdPrefix = statsdPrefix.replace("${context}", contextPath.replace("/", "")).
-					replace("${host}", hostName);
+			String statsdPrefix = Parameter.STATSD_PREFIX.getValue();
+			if (statsdPrefix == null) {
+				// contextPath est du genre "/testapp"
+				// hostName est du genre "www.host.com"
+				statsdPrefix = "javamelody." + contextPath.replace("/", "") + "." + hostName + ".";
+			}
 
 			try {
 				return new Statsd(InetAddress.getByName(address), port, statsdPrefix);
@@ -139,9 +140,5 @@ class Statsd extends MetricsPublisher {
 	@Override
 	public void stop() {
 		// nothing
-	}
-
-	public String getPrefix() {
-		return prefix;
 	}
 }

--- a/javamelody-core/src/test/java/net/bull/javamelody/internal/publish/TestStatsD.java
+++ b/javamelody-core/src/test/java/net/bull/javamelody/internal/publish/TestStatsD.java
@@ -62,23 +62,6 @@ public class TestStatsD {
 		statsd.stop();
 	}
 
-	/** Test prefix.
-	 * @throws IOException e */
-	@Test
-	public void testPrefix() throws IOException {
-		setProperty(Parameter.STATSD_ADDRESS, "localhost:8125");
-		Statsd statsd = Statsd.getInstance("/test", "hostname");
-		assertEquals("default prefix", "javamelody.test.hostname.", statsd.getPrefix());
-
-		setProperty(Parameter.STATSD_PREFIX, "javamelody.");
-		statsd = Statsd.getInstance("/test", "hostname");
-		assertEquals("short prefix", "javamelody.", statsd.getPrefix());
-
-		setProperty(Parameter.STATSD_PREFIX, "javamelody.${host}.");
-		statsd = Statsd.getInstance("/test", "host");
-		assertEquals("hostname prefix", "javamelody.host.", statsd.getPrefix());
-	}
-
 	private static void setProperty(Parameter parameter, String value) {
 		Utils.setProperty(parameter, value);
 	}

--- a/javamelody-core/src/test/java/net/bull/javamelody/internal/publish/TestStatsD.java
+++ b/javamelody-core/src/test/java/net/bull/javamelody/internal/publish/TestStatsD.java
@@ -19,7 +19,6 @@ package net.bull.javamelody.internal.publish;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 

--- a/javamelody-core/src/test/java/net/bull/javamelody/internal/publish/TestStatsD.java
+++ b/javamelody-core/src/test/java/net/bull/javamelody/internal/publish/TestStatsD.java
@@ -19,6 +19,7 @@ package net.bull.javamelody.internal.publish;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 
@@ -59,6 +60,23 @@ public class TestStatsD {
 		statsd = Statsd.getInstance("/test", "hostname");
 		assertNotNull("getInstance", statsd);
 		statsd.stop();
+	}
+
+	/** Test prefix.
+	 * @throws IOException e */
+	@Test
+	public void testPrefix() throws IOException {
+		setProperty(Parameter.STATSD_ADDRESS, "localhost:8125");
+		Statsd statsd = Statsd.getInstance("/test", "hostname");
+		assertEquals("default prefix", "javamelody.test.hostname.", statsd.getPrefix());
+
+		setProperty(Parameter.STATSD_PREFIX, "javamelody.");
+		statsd = Statsd.getInstance("/test", "hostname");
+		assertEquals("short prefix", "javamelody.", statsd.getPrefix());
+
+		setProperty(Parameter.STATSD_PREFIX, "javamelody.${host}.");
+		statsd = Statsd.getInstance("/test", "host");
+		assertEquals("hostname prefix", "javamelody.host.", statsd.getPrefix());
 	}
 
 	private static void setProperty(Parameter parameter, String value) {


### PR DESCRIPTION
If `true` then context and host will not be included in the metric name. The default value is false to keep the backward compatibility.