### PR TITLE
New parameter datadog-api-host for specifying Datadog base API host such as api.datadoghq.eu.

### DIFF
--- a/javamelody-core/src/main/java/net/bull/javamelody/Parameter.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/Parameter.java
@@ -395,9 +395,9 @@ public enum Parameter {
 	DATADOG_API_KEY("datadog-api-key"),
 
 	/**
-	 * <a href='https://www.datadog.com/'>Datadog</a> host for accessing API. 'https://api.datadoghq.com' is default.
+	 * <a href='https://www.datadog.com/'>Datadog</a> host for accessing API. 'api.datadoghq.com' is default.
 	 */
-	DATADOG_HOST("datadog-host");
+	DATADOG_API_HOST("datadog-api-host");
 
 	private final String code;
 

--- a/javamelody-core/src/main/java/net/bull/javamelody/Parameter.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/Parameter.java
@@ -392,7 +392,12 @@ public enum Parameter {
 	 * API key of the <a href='https://www.datadoghq.com/'>Datadog</a> to send metrics,
 	 * for example: 9775a026f1ca7d1c6c5af9d94d9595a4 (null by default).
 	 */
-	DATADOG_API_KEY("datadog-api-key");
+	DATADOG_API_KEY("datadog-api-key"),
+
+	/**
+	 * <a href='https://www.datadog.com/'>Datadog</a> host for accessing API. 'https://api.datadoghq.com' is default.
+	 */
+	DATADOG_HOST("datadog-host");
 
 	private final String code;
 

--- a/javamelody-core/src/main/java/net/bull/javamelody/internal/publish/Datadog.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/internal/publish/Datadog.java
@@ -60,9 +60,12 @@ class Datadog extends MetricsPublisher {
 		assert datadogApiKey != null;
 		assert prefix != null;
 		assert hostAndTags != null;
+		String datadogHost = Parameter.DATADOG_HOST.getValue();
+		if (datadogHost == null) {
+			datadogHost = "https://api.datadoghq.com";
+		}
 		try {
-			this.datadogUrl = new URL(
-					"https://app.datadoghq.com/api/v1/series?api_key=" + datadogApiKey);
+			this.datadogUrl = new URL(datadogHost + "/api/v1/series?api_key=" + datadogApiKey);
 		} catch (final MalformedURLException e) {
 			throw new IllegalArgumentException(e);
 		}

--- a/javamelody-core/src/main/java/net/bull/javamelody/internal/publish/Datadog.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/internal/publish/Datadog.java
@@ -55,17 +55,13 @@ class Datadog extends MetricsPublisher {
 	private String lastTimestamp;
 	private boolean beginSeries;
 
-	Datadog(String datadogApiKey, String prefix, String hostAndTags) {
+	Datadog(String datadogApiKey, String datadogApiHost, String prefix, String hostAndTags) {
 		super();
 		assert datadogApiKey != null;
 		assert prefix != null;
 		assert hostAndTags != null;
-		String datadogHost = Parameter.DATADOG_HOST.getValue();
-		if (datadogHost == null) {
-			datadogHost = "https://api.datadoghq.com";
-		}
 		try {
-			this.datadogUrl = new URL(datadogHost + "/api/v1/series?api_key=" + datadogApiKey);
+			this.datadogUrl = new URL("https://" + datadogApiHost + "/api/v1/series?api_key=" + datadogApiKey);
 		} catch (final MalformedURLException e) {
 			throw new IllegalArgumentException(e);
 		}
@@ -83,6 +79,11 @@ class Datadog extends MetricsPublisher {
 	static Datadog getInstance(String contextPath, String hostName) {
 		final String datadogApiKey = Parameter.DATADOG_API_KEY.getValue();
 		if (datadogApiKey != null) {
+			String datadogApiHost = Parameter.DATADOG_API_HOST.getValue();
+			if (datadogApiHost == null) {
+				datadogApiHost = "api.datadoghq.com";
+			}
+
 			assert contextPath != null;
 			assert hostName != null;
 			// contextPath est du genre "/testapp"
@@ -92,7 +93,7 @@ class Datadog extends MetricsPublisher {
 			// see https://help.datadoghq.com/hc/en-us/articles/203764705-What-are-valid-metric-names-
 			final String hostAndTags = "\"host\":\"" + hostName + "\",\"tags\":[\"application:"
 					+ contextPath + "\"]";
-			return new Datadog(datadogApiKey, prefix, hostAndTags);
+			return new Datadog(datadogApiKey, datadogApiHost, prefix, hostAndTags);
 		}
 		return null;
 	}


### PR DESCRIPTION
Needed for non-US Datadog sites (for example https://api.datadoghq.eu).