### PR TITLE
added I18N thousand separator for number of MBean

### DIFF
--- a/javamelody-core/src/main/java/net/bull/javamelody/internal/model/MBeans.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/internal/model/MBeans.java
@@ -23,8 +23,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
 
@@ -39,6 +41,7 @@ import javax.management.ObjectName;
 import javax.management.openmbean.CompositeData;
 import javax.management.openmbean.TabularData;
 
+import net.bull.javamelody.internal.common.I18N;
 import net.bull.javamelody.internal.common.LOG;
 import net.bull.javamelody.internal.model.MBeanNode.MBeanAttribute;
 
@@ -247,10 +250,33 @@ public final class MBeans {
 					} else {
 						sb.append(",\n");
 					}
-					sb.append(value);
+					if (attributeValue instanceof Number) {
+						sb.append(I18N.createIntegerFormat().format(attributeValue));
+					} else {
+						sb.append(value);
+					}
 				}
 				sb.append(']');
 				return sb.toString();
+			}
+			if (attributeValue instanceof Map) {
+				@SuppressWarnings("unchecked")
+				Map<Object, Object> map = (Map<Object, Object>) attributeValue;
+
+				LinkedHashMap<Object, Object> mapToString = new LinkedHashMap<>();
+
+				for (Entry<Object, Object> e : map.entrySet()) {
+					Object v = e.getValue();
+					if (v instanceof Number) {
+						mapToString.put(e.getKey(), I18N.createIntegerFormat().format(v));
+					} else {
+						mapToString.put(e.getKey(), attributeValue);
+					}
+				}
+				return mapToString.toString();
+			}
+			if (attributeValue instanceof Number) {
+				return I18N.createIntegerFormat().format(attributeValue);
 			}
 			return String.valueOf(attributeValue);
 		} catch (final Exception e) {

--- a/javamelody-core/src/test/java/net/bull/javamelody/internal/model/TestMBeans.java
+++ b/javamelody-core/src/test/java/net/bull/javamelody/internal/model/TestMBeans.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertNotNull;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
 import javax.management.JMException;
 import javax.management.MBeanServer;
@@ -34,6 +35,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import net.bull.javamelody.Utils;
+import net.bull.javamelody.internal.common.I18N;
 import net.bull.javamelody.internal.model.MBeanNode.MBeanAttribute;
 import net.bull.javamelody.internal.model.TestTomcatInformations.GlobalRequestProcessor;
 import net.bull.javamelody.internal.model.TestTomcatInformations.ThreadPool;
@@ -158,5 +160,68 @@ public class TestMBeans {
 		} catch (final IllegalArgumentException e) {
 			assertNotNull("e", e);
 		}
+	}
+
+	private String find(String name1, String name2, String name3, String attributeName)
+			throws JMException {
+		for (MBeanNode mBeanNode : MBeans.getAllMBeanNodes()) {
+			for (MBeanNode children : mBeanNode.getChildren()) {
+				if (children.getName().equals(name1)) {
+					for (MBeanNode cc : children.getChildren()) {
+						if (cc.getName().equals(name2)) {
+							for (MBeanNode ccc : cc.getChildren()) {
+								if (ccc.getName().equals(name3)) {
+									for (MBeanAttribute aaa : ccc.getAttributes()) {
+										if (aaa.getName().equals(attributeName)) {
+											return aaa.getFormattedValue();
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		return null;
+	}
+
+	@Test
+	public void testGetConvertedAttribute_I18N() throws JMException {
+		final ObjectInstance mBean1 = mBeanServer.registerMBean(new ThreadPool() {
+			@Override
+			public int getmaxThreads() {
+				return 1234;
+			}
+
+		}, new ObjectName("Catalina:type=ThreadPool2"));
+		mbeansList.add(mBean1.getObjectName());
+
+		final String message = "testGetConvertedAttribute_I18N";
+		I18N.bindLocale(Locale.US);
+		assertEquals(message, "1,234",
+				find("Catalina", "ThreadPool2", "Catalina:type=ThreadPool2", "maxThreads"));
+		assertEquals(message, "{committed=1, init=10, max=100, used=1,000}",
+				find("Catalina", "ThreadPool2", "Catalina:type=ThreadPool2", "memoryUsage"));
+		I18N.bindLocale(Locale.FRANCE);
+		assertEquals(message, "1\u00a0234",
+				find("Catalina", "ThreadPool2", "Catalina:type=ThreadPool2", "maxThreads"));
+		assertEquals(message, "{committed=1, init=10, max=100, used=1\u00a0000}",
+				find("Catalina", "ThreadPool2", "Catalina:type=ThreadPool2", "memoryUsage"));
+		I18N.bindLocale(Locale.FRENCH);
+		assertEquals(message, "1\u00a0234",
+				find("Catalina", "ThreadPool2", "Catalina:type=ThreadPool2", "maxThreads"));
+		assertEquals(message, "{committed=1, init=10, max=100, used=1\u00a0000}",
+				find("Catalina", "ThreadPool2", "Catalina:type=ThreadPool2", "memoryUsage"));
+		I18N.bindLocale(Locale.ITALIAN);
+		assertEquals(message, "1.234",
+				find("Catalina", "ThreadPool2", "Catalina:type=ThreadPool2", "maxThreads"));
+		assertEquals(message, "{committed=1, init=10, max=100, used=1.000}",
+				find("Catalina", "ThreadPool2", "Catalina:type=ThreadPool2", "memoryUsage"));
+		I18N.bindLocale(Locale.ITALY);
+		assertEquals(message, "1.234",
+				find("Catalina", "ThreadPool2", "Catalina:type=ThreadPool2", "maxThreads"));
+		assertEquals(message, "{committed=1, init=10, max=100, used=1.000}",
+				find("Catalina", "ThreadPool2", "Catalina:type=ThreadPool2", "memoryUsage"));
 	}
 }

--- a/javamelody-core/src/test/java/net/bull/javamelody/internal/model/TestTomcatInformations.java
+++ b/javamelody-core/src/test/java/net/bull/javamelody/internal/model/TestTomcatInformations.java
@@ -25,7 +25,9 @@ import static org.junit.Assert.assertNotNull;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.management.JMException;
 import javax.management.MBeanServer;
@@ -75,6 +77,21 @@ public class TestTomcatInformations {
 
 		/** {@inheritDoc} */
 		@Override
+		public Map<Object, Object> getmemoryUsage() {
+			return new LinkedHashMap<Object, Object>() {
+				private static final long serialVersionUID = 1L;
+
+				{
+					this.put("committed", 1);
+					this.put("init", 10);
+					this.put("max", 100);
+					this.put("used", 1000);
+				}
+			};
+		}
+
+		/** {@inheritDoc} */
+		@Override
 		public Object gettoStringException() {
 			return new Object() {
 				/** {@inheritDoc} */
@@ -108,6 +125,13 @@ public class TestTomcatInformations {
 		 * @return int
 		 */
 		int getmaxThreads();
+
+		/** {@inheritDoc} */
+		/**
+		 * attribut memoryUsage.
+		 * @return MemoryUsage
+		 */
+		Map<Object, Object> getmemoryUsage();
 
 		/**
 		 * attribut currentThreadsBusy.


### PR DESCRIPTION
This help read big number (like memory on MemoryPool). I wish to hide
this feature behind some config, but I can't find a way too do this.

For I18N net.bull.javamelody.internal.common.I18N is used