### PR TITLE
CSP: Fix single and double quote HTML escaping

### DIFF
--- a/javamelody-core/src/main/java/net/bull/javamelody/internal/common/I18N.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/internal/common/I18N.java
@@ -135,7 +135,7 @@ public final class I18N {
 	public static String htmlEncode(String text, boolean encodeSpace, boolean encodeNewLine) {
 		// ces encodages html sont incomplets mais suffisants pour le monitoring
 		String result = text.replaceAll("[&]", "&amp;").replaceAll("[<]", "&lt;")
-				.replaceAll("[>]", "&gt;").replaceAll("'", "&#39;").replaceAll("\"", "&#34;");
+				.replaceAll("[>]", "&gt;").replaceAll("'", "&apos;").replaceAll("\"", "&quot;");
 		if (encodeSpace) {
 			result = result.replaceAll(" ", "&nbsp;");
 		}


### PR DESCRIPTION
`#` cannot be used because it's used to indicate message keys to lookup.
So instead use alternative representations that don't use `#`