### PR TITLE
Only run PROBLEMATIC_ATTRIBUTE_READING check if IE

### DIFF
--- a/javamelody-core/src/main/resources/net/bull/javamelody/resource/prototype.js
+++ b/javamelody-core/src/main/resources/net/bull/javamelody/resource/prototype.js
@@ -2773,9 +2773,9 @@ Ajax.PeriodicalUpdater = Class.create(Ajax.Base, {
     var isFunction = Object.isArray(value);
     DIV.removeAttribute('onclick');
     return isFunction;
-  })();
+  });
 
-  if (PROBLEMATIC_ATTRIBUTE_READING) {
+  if (Prototype.Browser.IE && PROBLEMATIC_ATTRIBUTE_READING()) {
     readAttribute = readAttribute_IE;
   } else if (Prototype.Browser.Opera) {
     readAttribute = readAttribute_Opera;


### PR DESCRIPTION
Avoid a CSP inline script violation.

See: https://github.com/prototypejs/prototype/issues/320

This change is required for eventual CSP support.