### PR TITLE
Add feature "export current Requests over time"

### DIFF
--- a/javamelody-core/src/main/java/net/bull/javamelody/Parameter.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/Parameter.java
@@ -403,7 +403,17 @@ public enum Parameter {
 	/**
 	 * <a href='https://www.datadog.com/'>Datadog</a> host for accessing API. 'api.datadoghq.com' is default.
 	 */
-	DATADOG_API_HOST("datadog-api-host");
+	DATADOG_API_HOST("datadog-api-host"),
+
+	/**
+	 * Integer value as minimum time collector for current requests
+	 */
+	CURRENT_REQUEST_MIN_DURATION_LOG("current-request-min-duration"),
+
+	/**
+	 * Integer value as minimum time collector for current requests
+	 */
+	CURRENT_REQUEST_STACKTRACE_SIZE("current-request-stacktrace-size");
 
 	private final String code;
 

--- a/javamelody-core/src/main/java/net/bull/javamelody/internal/model/CounterRequestContext.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/internal/model/CounterRequestContext.java
@@ -50,6 +50,7 @@ public class CounterRequestContext implements ICounterRequestContext, Cloneable,
 	private final long threadId;
 	// attention, si sérialisation vers serveur de collecte, la durée peut être impactée s'il y a désynchronisation d'horloge
 	private final long startTime;
+	private final long currentTime;
 	private final long startCpuTime;
 	private final long startAllocatedBytes;
 	private final String sessionId;
@@ -93,6 +94,7 @@ public class CounterRequestContext implements ICounterRequestContext, Cloneable,
 		this.remoteUser = remoteUser;
 		this.threadId = threadId;
 		this.startTime = startTime;
+		this.currentTime = System.currentTimeMillis() - startTime;
 		this.startCpuTime = startCpuTime;
 		this.startAllocatedBytes = startAllocatedBytes;
 		this.sessionId = sessionId;
@@ -170,6 +172,8 @@ public class CounterRequestContext implements ICounterRequestContext, Cloneable,
 	public long getThreadId() {
 		return threadId;
 	}
+
+	public long getCurrentTime() { return currentTime; }
 
 	public int getDuration(long timeOfSnapshot) {
 		// durée écoulée (non négative même si resynchro d'horloge)
@@ -349,7 +353,7 @@ public class CounterRequestContext implements ICounterRequestContext, Cloneable,
 	public String toString() {
 		return getClass().getSimpleName() + "[parentCounter=" + getParentCounter().getName()
 				+ ", completeRequestName=" + getCompleteRequestName() + ", threadId="
-				+ getThreadId() + ", startTime=" + startTime + ", childHits=" + getChildHits()
+				+ getThreadId() + ", startTime=" + startTime + ", currentTime=" + currentTime + ", childHits=" + getChildHits()
 				+ ", childDurationsSum=" + getChildDurationsSum() + ", childContexts="
 				+ getChildContexts() + ']';
 	}

--- a/javamelody-core/src/main/java/net/bull/javamelody/internal/publish/CloudWatch.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/internal/publish/CloudWatch.java
@@ -141,6 +141,9 @@ class CloudWatch extends MetricsPublisher {
 	}
 
 	@Override
+	public void addValue(String metric, String value) {}
+
+	@Override
 	public void send() throws IOException {
 		final List<MetricDatum> datumList;
 		synchronized (buffer) {

--- a/javamelody-core/src/main/java/net/bull/javamelody/internal/publish/Graphite.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/internal/publish/Graphite.java
@@ -114,6 +114,18 @@ class Graphite extends MetricsPublisher {
 	}
 
 	@Override
+	public synchronized void addValue(String metric, String value) throws IOException {
+		final long timeInSeconds = System.currentTimeMillis() / 1000;
+		if (lastTime != timeInSeconds) {
+			lastTimestamp = String.valueOf(timeInSeconds);
+			lastTime = timeInSeconds;
+		}
+		bufferWriter.append(prefix).append(metric).append(SEPARATOR);
+		bufferWriter.append(value).append(SEPARATOR);
+		bufferWriter.append(lastTimestamp).append('\n');
+	}
+
+	@Override
 	public synchronized void send() throws IOException {
 		try {
 			bufferWriter.flush();

--- a/javamelody-core/src/main/java/net/bull/javamelody/internal/publish/InfluxDB.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/internal/publish/InfluxDB.java
@@ -102,6 +102,20 @@ class InfluxDB extends MetricsPublisher {
 	}
 
 	@Override
+	public synchronized void addValue(String metric, String value) throws IOException {
+		// ex curl -i -XPOST 'http://localhost:8086/write?db=mydb&precision=s' --data-binary
+		// 'cpu_load_short,direction=in,host=server01,region=us-west value=2.0 1422568543702'
+		final long timeInSeconds = System.currentTimeMillis() / 1000;
+		if (lastTime != timeInSeconds) {
+			lastTimestamp = String.valueOf(timeInSeconds);
+			lastTime = timeInSeconds;
+		}
+		bufferWriter.append(prefix).append(metric).append(tags).append(SEPARATOR);
+		bufferWriter.append("value=").append('"'+value+'"').append(SEPARATOR);
+		bufferWriter.append(lastTimestamp).append('\n');
+	}
+
+	@Override
 	public synchronized void send() throws IOException {
 		try {
 			bufferWriter.flush();

--- a/javamelody-core/src/main/java/net/bull/javamelody/internal/publish/MetricsPublisher.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/internal/publish/MetricsPublisher.java
@@ -85,6 +85,8 @@ public abstract class MetricsPublisher {
 
 	public abstract void addValue(String metric, double value) throws IOException;
 
+	public abstract void addValue(String metric, String value) throws IOException;
+
 	public abstract void send() throws IOException;
 
 	public abstract void stop();

--- a/javamelody-core/src/main/java/net/bull/javamelody/internal/publish/Statsd.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/internal/publish/Statsd.java
@@ -104,6 +104,15 @@ class Statsd extends MetricsPublisher {
 	}
 
 	@Override
+	public synchronized void addValue(String metric, String value) throws IOException {
+		// String.format(Locale.ENGLISH, "%s:%d|ms", key, value) for a timing value
+		// String.format(Locale.ENGLISH, "%s:%s|c", key, magnitude) to increment a counter
+		// String.format(Locale.ENGLISH, "%s:%s|g", key, value) for a gauge value
+		bufferWriter.append(prefix).append(metric).append(':');
+		bufferWriter.append(value).append("|g\n");
+	}
+
+	@Override
 	public synchronized void send() throws IOException {
 		try {
 			bufferWriter.flush();


### PR DESCRIPTION
Export current requests (stackTrace, current time, thread id) over time controled by parameters "CURRENT_REQUEST_MIN_DURATION_LOG" and "CURRENT_REQUEST_STACKTRACE_SIZE"

This feature is helpfull to indentify patterns that stuck the threads after the problem has occurred.
Can be controled by parameter to set the minimum time that a requests need to have to be exported and the size of his stack trace.