### PR TITLE
fix Hibernate criteria query naming

### DIFF
--- a/javamelody-core/pom.xml
+++ b/javamelody-core/pom.xml
@@ -51,7 +51,7 @@
 			<version>1.5.9</version>
 		</dependency>
 
-		<!-- following dependencies are not transitive: they are provided, test 
+		<!-- following dependencies are not transitive: they are provided, test
 			or optional -->
 		<dependency>
 			<groupId>javax.servlet</groupId>
@@ -163,9 +163,9 @@
 			<version>1.5.2</version>
 			<optional>true</optional>
 		</dependency>
-		<!-- <dependency> <groupId>org.quartz-scheduler</groupId> <artifactId>quartz</artifactId> 
-			<version>2.1.2</version> <optional>true</optional> <exclusions> <exclusion> 
-			<artifactId>c3p0</artifactId> <groupId>c3p0</groupId> </exclusion> </exclusions> 
+		<!-- <dependency> <groupId>org.quartz-scheduler</groupId> <artifactId>quartz</artifactId>
+			<version>2.1.2</version> <optional>true</optional> <exclusions> <exclusion>
+			<artifactId>c3p0</artifactId> <groupId>c3p0</groupId> </exclusion> </exclusions>
 			</dependency> -->
 		<dependency>
 			<groupId>com.thoughtworks.xstream</groupId>
@@ -209,7 +209,13 @@
 			<version>10.0.8</version>
 			<optional>true</optional>
 		</dependency>
-		<!-- Dépendance optionnelle spring web (qui inclus spring core, spring 
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-core</artifactId>
+			<version>5.6.0.Final</version>
+			<optional>true</optional>
+		</dependency>
+		<!-- Dépendance optionnelle spring web (qui inclus spring core, spring
 			beans, spring aop) -->
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -351,11 +357,11 @@
 					<source>1.7</source>
 					<target>1.7</target>
 					<fork>true</fork>
-					<!-- pour éviter warning dans Maven sur sun.nio.ch.DirectBuffer dans 
+					<!-- pour éviter warning dans Maven sur sun.nio.ch.DirectBuffer dans
 						RrdNioBackend -->
 					<compilerArgument>-XDignore.symbol.file=true -Xlint</compilerArgument>
 					<showWarnings>true</showWarnings>
-					<!-- pour éviter warning dans Maven sur sun.misc.BASE64Encoder dans 
+					<!-- pour éviter warning dans Maven sur sun.misc.BASE64Encoder dans
 						le test unitaire TestBase64Coder -->
 					<testCompilerArgument>-XDignore.symbol.file=true -Xlint</testCompilerArgument>
 				</configuration>


### PR DESCRIPTION
Since Hibernate 5.2 CriteriaQueries are recorded as `org.hibernate.query.internal.QueryImpl@HexString`. Prior work from #567 is broken.

Your implementation has been relying on the [toString() method of Hibernate's QueryImpl](https://github.com/hibernate/hibernate-orm/blob/e5354731fb502feb09d46e97ca71af2f6b790190/hibernate-core/src/main/java/org/hibernate/internal/AbstractQueryImpl.java#L119-L122).

However, since Hibernate 5.2, QueryImpl does not override toString() any more.

Inorder to provide a more future proof method, I suggest to call the public API method [`getQueryString()`](https://github.com/hibernate/hibernate-orm/blob/412e08c1941b04c0a0cbcfd08c68f813c07bb9bb/hibernate-core/src/main/java/org/hibernate/Query.java#L65) instead.

This pull request call `getQueryString()` instead of `toString()` and handles the deprecation of `org.hibernate.Query`, which will be removed in the upcoming Hibernate 6.0 release.