### PR TITLE
Fix: prometheus metrix endpoint returning empty data

### DIFF
--- a/javamelody-core/src/main/java/net/bull/javamelody/internal/web/MonitoringController.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/internal/web/MonitoringController.java
@@ -161,6 +161,8 @@ public class MonitoringController {
 		}
 
 		doReport(httpRequest, httpResponse, Collections.singletonList(javaInformations));
+
+		httpResponse.flushBuffer();
 	}
 
 	public void doReport(HttpServletRequest httpRequest, HttpServletResponse httpResponse,
@@ -247,6 +249,8 @@ public class MonitoringController {
 		final PrometheusController prometheusController = new PrometheusController(
 				javaInformationsList, collector, httpResponse.getWriter());
 		prometheusController.report(includeLastValue);
+
+		httpResponse.getWriter().flush();
 	}
 
 	public static void noCache(HttpServletResponse httpResponse) {


### PR DESCRIPTION
This is a fix of https://github.com/javamelody/javamelody/issues/1064