### PR TITLE
Improve word wrap for long ?,?,? parameters

### DIFF
--- a/javamelody-core/src/main/resources/net/bull/javamelody/resource/monitoring.css
+++ b/javamelody-core/src/main/resources/net/bull/javamelody/resource/monitoring.css
@@ -102,7 +102,8 @@ table thead th:last-child {
 
 .wrappedText {
 	/* wrap very long words in requests and errors cells */
-	word-wrap: anywhere;
+	overflow-wrap: anywhere;
+
 	word-break: break-all;
 }
 
@@ -129,8 +130,8 @@ table thead th:last-child {
 	position: absolute;
 	top: 12px;
 	left: 20px;
-	/* une width fixe est nÈcessaire pour MSIE 7,
-	mais cela g‚cherait tout sur firefox, chrome ou MSIE8 qui n'en ont pas besoin
+	/* une width fixe est n√©cessaire pour MSIE 7,
+	mais cela g√¢cherait tout sur firefox, chrome ou MSIE8 qui n'en ont pas besoin
 	width: 800px; */
 	border-radius: 6px;
 	padding: 5px;

--- a/javamelody-core/src/main/resources/net/bull/javamelody/resource/monitoring.css
+++ b/javamelody-core/src/main/resources/net/bull/javamelody/resource/monitoring.css
@@ -102,7 +102,7 @@ table thead th:last-child {
 
 .wrappedText {
 	/* wrap very long words in requests and errors cells */
-	word-wrap: break-word;
+	word-wrap: anywhere;
 	word-break: break-all;
 }
 


### PR DESCRIPTION
Currently, JavaMelody wraps long queries like this

![grafik](https://user-images.githubusercontent.com/5530228/160346034-710b7265-b755-47fc-8d29-a5d7877b63ee.png)

It is currently done in words with `break-words` (which makes them harder to read) but this does not work on `(?,?,?)` strings:

![grafik](https://user-images.githubusercontent.com/5530228/160346189-1460f9f8-00bf-4dec-b3b1-8365d8a32d65.png)

This may cause ultra-wide tables as mentioned in #1098 

Changing `break-words` to `anywhere` will work also on `(?,?,?)` strings (and gives same hard-to-read results)

![grafik](https://user-images.githubusercontent.com/5530228/160347025-f5d85ce6-2de7-45ce-94e1-d183f4603a56.png)

I have also tested `table-layout: fixed` This would give the best wrap result, but it messes up the table layout:

![grafik](https://user-images.githubusercontent.com/5530228/160347836-660f8333-0896-4be2-a9f8-10bf9904ce8c.png)

