### PR TITLE
fix(sec): upgrade com.amazonaws:aws-java-sdk-s3 to 1.12.261

### DIFF
--- a/javamelody-collector-server/pom.xml
+++ b/javamelody-collector-server/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>net.bull.javamelody</groupId>
 	<artifactId>javamelody-collector-server</artifactId>
@@ -87,7 +85,7 @@
 		<dependency>
 			<groupId>com.amazonaws</groupId>
 			<artifactId>aws-java-sdk-s3</artifactId>
-			<version>1.11.136</version>
+			<version>1.12.261</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/javamelody-core/pom.xml
+++ b/javamelody-core/pom.xml
@@ -284,7 +284,7 @@
 		<dependency>
 			<groupId>com.amazonaws</groupId>
 			<artifactId>aws-java-sdk-s3</artifactId>
-			<version>1.11.136</version>
+			<version>1.12.261</version>
 			<optional>true</optional>
 		</dependency>
 		<!-- Dépendance JUnit -->

--- a/javamelody-test-webapp/pom.xml
+++ b/javamelody-test-webapp/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>net.bull.javamelody</groupId>
@@ -216,7 +214,7 @@
 		<dependency>
 			<groupId>com.amazonaws</groupId>
 			<artifactId>aws-java-sdk-s3</artifactId>
-			<version>1.11.136</version>
+			<version>1.12.261</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
@@ -271,8 +269,7 @@
 					<contextPath>/</contextPath>
 					<scanIntervalSeconds>10</scanIntervalSeconds>
 					<connectors>
-						<connector
-							implementation="org.eclipse.jetty.server.nio.SelectChannelConnector">
+						<connector implementation="org.eclipse.jetty.server.nio.SelectChannelConnector">
 							<port>8080</port>
 							<maxIdleTime>60000</maxIdleTime>
 						</connector>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.amazonaws:aws-java-sdk-s3 1.11.136
- [CVE-2022-31159](https://www.oscs1024.com/hd/CVE-2022-31159)


### What did I do？
Upgrade com.amazonaws:aws-java-sdk-s3 from 1.11.136 to 1.12.261 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` succeeded locally.
Run `mvn clean test` succeeded locally. all tests passed.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS