### PR TITLE
fix(sec): upgrade org.springframework.data:spring-data-mongodb to 3.3.5

### DIFF
--- a/javamelody-core/pom.xml
+++ b/javamelody-core/pom.xml
@@ -238,7 +238,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>3.3.3</version>
+			<version>3.3.5</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>

--- a/javamelody-test-webapp/pom.xml
+++ b/javamelody-test-webapp/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>net.bull.javamelody</groupId>
@@ -179,7 +177,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-mongodb</artifactId>
-			<version>3.3.3</version>
+			<version>3.3.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.mongodb</groupId>
@@ -271,8 +269,7 @@
 					<contextPath>/</contextPath>
 					<scanIntervalSeconds>10</scanIntervalSeconds>
 					<connectors>
-						<connector
-							implementation="org.eclipse.jetty.server.nio.SelectChannelConnector">
+						<connector implementation="org.eclipse.jetty.server.nio.SelectChannelConnector">
 							<port>8080</port>
 							<maxIdleTime>60000</maxIdleTime>
 						</connector>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.springframework.data:spring-data-mongodb 3.3.3
- [CVE-2022-22980](https://www.oscs1024.com/hd/CVE-2022-22980)


### What did I do？
Upgrade org.springframework.data:spring-data-mongodb from 3.3.3 to 3.3.5 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` succeeded locally.
Run `mvn clean test` succeeded locally. all tests passed.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS