### PR TITLE
fix(sec): upgrade org.eclipse.jetty:jetty-servlet to 9.2.27.v20190403

### DIFF
--- a/javamelody-for-standalone/pom.xml
+++ b/javamelody-for-standalone/pom.xml
@@ -14,7 +14,7 @@
 	<properties>
 		<!-- Adapt this to a version found on http://central.maven.org/maven2/org/eclipse/jetty/jetty-maven-plugin/ -->
 		<!-- (9.2.21 is the last version supporting Java 7) -->
-		<jettyVersion>9.2.21.v20170120</jettyVersion>
+		<jettyVersion>9.2.27.v20190403</jettyVersion>
 		<!-- Adapt this to a version found on http://central.maven.org/maven2/net/bull/javamelody/javamelody-core/ -->
 		<javamelodyVersion>${project.version}</javamelodyVersion>
 

--- a/javamelody-offline-viewer/pom.xml
+++ b/javamelody-offline-viewer/pom.xml
@@ -14,7 +14,7 @@
 	<properties>
 		<!-- Adapt this to a version found on http://central.maven.org/maven2/org/eclipse/jetty/jetty-maven-plugin/ -->
 		<!-- (9.2.21 is the last version supporting Java 7) -->
-		<jettyVersion>9.2.21.v20170120</jettyVersion>
+		<jettyVersion>9.2.27.v20190403</jettyVersion>
 		<!-- Adapt this to a version found on http://central.maven.org/maven2/net/bull/javamelody/javamelody-core/ -->
 		<javamelodyVersion>${project.version}</javamelodyVersion>
 


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.eclipse.jetty:jetty-servlet 9.2.21.v20170120
- [CVE-2019-10241](https://www.oscs1024.com/hd/CVE-2019-10241)


### What did I do？
Upgrade org.eclipse.jetty:jetty-servlet from 9.2.21.v20170120 to 9.2.27.v20190403 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` succeeded locally.
Run `mvn clean test` succeeded locally. all tests passed.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS