### PR TITLE
catch the runtime exception while reading the gz files

### DIFF
--- a/javamelody-core/src/main/java/net/bull/javamelody/internal/model/CounterStorage.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/internal/model/CounterStorage.java
@@ -35,6 +35,7 @@ import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
 import net.bull.javamelody.Parameter;
+import net.bull.javamelody.internal.common.LOG;
 import net.bull.javamelody.internal.common.Parameters;
 
 /**
@@ -158,6 +159,11 @@ public class CounterStorage {
 			}
 		} catch (final ClassNotFoundException e) {
 			throw new IOException(e.getMessage(), e);
+		}
+		catch (final RuntimeException e) {
+			LOG.warn("could not deserialize " + file.getName() + " , corrupted file will be deleted.",e);
+			file.delete();
+			return null;
 		}
 	}
 

--- a/javamelody-core/src/test/java/net/bull/javamelody/internal/model/TestCounterStorage.java
+++ b/javamelody-core/src/test/java/net/bull/javamelody/internal/model/TestCounterStorage.java
@@ -25,6 +25,7 @@ import java.util.Calendar;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import net.bull.javamelody.Parameter;
 import net.bull.javamelody.Utils;
@@ -35,10 +36,24 @@ import net.bull.javamelody.internal.common.Parameters;
  * @author Emeric Vernat
  */
 public class TestCounterStorage {
+	
+	@Rule
+	public TemporaryFolder corruptedTempFile= new TemporaryFolder();
+	
 	/** Test. */
 	@Before
 	public void setUp() {
 		Utils.initialize();
+	}
+	
+	@Test
+	public void testCorruptedFile() throws IOException {
+		File tempFile = corruptedTempFile.newFile("test.ser.gz");
+		try(ObjectOutputStream outputStream = new ObjectOutputStream(new GZIPOutputStream(new FileOutputStream(tempFile)))){
+			outputStream.writeObject("java melody");
+		}
+		Assert.isNull(CounterStorage.readFromFile(tempFile),"String object can not be cast to the Counter, but the result should be null");
+		Assert.isTrue(!tempFile.exists(),"corrupted file should be deleted");
 	}
 
 	/** Test.


### PR DESCRIPTION
java.lang.IllegalStateException: unread block data
    at java.io.ObjectInputStream$BlockDataInputStream.setBlockDataMode(ObjectInputStream.java:2899)
    at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1700)
    at java.io.ObjectInputStream.defaultReadFields(ObjectInputStream.java:2403)
    at java.io.ObjectInputStream.readSerialData(ObjectInputStream.java:2327)
    at java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2185)
    at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1665)
    at java.io.ObjectInputStream.readObject(ObjectInputStream.java:501)
    at java.io.ObjectInputStream.readObject(ObjectInputStream.java:459)
    at net.bull.javamelody.internal.model.CounterStorage.readFromFile(CounterStorage.java:164)
    at net.bull.javamelody.internal.model.CounterStorage.readFromFile(CounterStorage.java:151)
    at net.bull.javamelody.internal.model.Counter.readFromFile(Counter.java:970)
    at net.bull.javamelody.internal.model.Collector.<init>(Collector.java:121)
    at net.bull.javamelody.FilterContext.<init>(FilterContext.java:151)
    at net.bull.javamelody.MonitoringFilter.init(MonitoringFilter.java:148)



Caused by: java.lang.ClassCastException: cannot assign instance of java.lang.String to field net.bull.javamelody.internal.model.CounterRequest.rumData of type net.bull.javamelody.internal.model.CounterRequestRumData in instance of net.bull.javamelody.internal.model.CounterRequest
at java.io.ObjectStreamClass$FieldReflector.setObjFieldValues(ObjectStreamClass.java:2301) [rt.jar:1.8.0_322]
at java.io.ObjectStreamClass.setObjFieldValues(ObjectStreamClass.java:1431) [rt.jar:1.8.0_322]
at java.io.ObjectInputStream.defaultReadFields(ObjectInputStream.java:2437) [rt.jar:1.8.0_322]
at java.io.ObjectInputStream.readSerialData(ObjectInputStream.java:2355) [rt.jar:1.8.0_322]
at java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2213) [rt.jar:1.8.0_322]
at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1669) [rt.jar:1.8.0_322]
at java.io.ObjectInputStream.readObject(ObjectInputStream.java:503) [rt.jar:1.8.0_322]
at java.io.ObjectInputStream.readObject(ObjectInputStream.java:461) [rt.jar:1.8.0_322]
at java.util.concurrent.ConcurrentHashMap.readObject(ConcurrentHashMap.java:1445) [rt.jar:1.8.0_322]
at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) [rt.jar:1.8.0_322]
at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) [rt.jar:1.8.0_322]
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) [rt.jar:1.8.0_322]
at java.lang.reflect.Method.invoke(Method.java:498) [rt.jar:1.8.0_322]
at java.io.ObjectStreamClass.invokeReadObject(ObjectStreamClass.java:1184) [rt.jar:1.8.0_322]
at java.io.ObjectInputStream.readSerialData(ObjectInputStream.java:2322) [rt.jar:1.8.0_322]
at java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2213) [rt.jar:1.8.0_322]
at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1669) [rt.jar:1.8.0_322]
at java.io.ObjectInputStream.defaultReadFields(ObjectInputStream.java:2431) [rt.jar:1.8.0_322]
at java.io.ObjectInputStream.readSerialData(ObjectInputStream.java:2355) [rt.jar:1.8.0_322]
at java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2213) [rt.jar:1.8.0_322]
at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1669) [rt.jar:1.8.0_322]
at java.io.ObjectInputStream.readObject(ObjectInputStream.java:503) [rt.jar:1.8.0_322]
at java.io.ObjectInputStream.readObject(ObjectInputStream.java:461) [rt.jar:1.8.0_322]
at net.bull.javamelody.internal.model.CounterStorage.readFromFile(CounterStorage.java:164)
at net.bull.javamelody.internal.model.CounterStorage.readFromFile(CounterStorage.java:151)
at net.bull.javamelody.internal.model.Counter.readFromFile(Counter.java:970)
at net.bull.javamelody.internal.model.Collector.<init>(Collector.java:121)
at net.bull.javamelody.FilterContext.<init>(FilterContext.java:151)
at net.bull.javamelody.MonitoringFilter.init(MonitoringFilter.java:148)

these are the stack traces from our server that shows for some reason it can not deserialize objects from the storage, so the filter is broken and the application won't start up. in production, the only solution is to remove those corrupted files and restarting the server.