### PR TITLE
Update to OpenPDF 1.3.33

### DIFF
--- a/javamelody-collector-server/pom.xml
+++ b/javamelody-collector-server/pom.xml
@@ -39,9 +39,9 @@
 			packaging maven n'est pas exactement le même que le vrai war produit par 
 			build.xml -->
 		<dependency>
-			<groupId>com.lowagie</groupId>
-			<artifactId>itext</artifactId>
-			<version>2.1.7</version>
+			<groupId>com.github.librepdf</groupId>
+			<artifactId>openpdf</artifactId>
+			<version>1.3.33</version>
 			<exclusions>
 				<exclusion>
 					<groupId>bouncycastle</groupId>

--- a/javamelody-core/pom.xml
+++ b/javamelody-core/pom.xml
@@ -146,9 +146,9 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>com.lowagie</groupId>
-			<artifactId>itext</artifactId>
-			<version>2.1.7</version>
+			<groupId>com.github.librepdf</groupId>
+			<artifactId>openpdf</artifactId>
+			<version>1.3.33</version>
 			<optional>true</optional>
 			<exclusions>
 				<exclusion>

--- a/javamelody-core/src/main/java/net/bull/javamelody/internal/common/I18N.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/internal/common/I18N.java
@@ -209,7 +209,7 @@ public final class I18N {
 		final DecimalFormatSymbols symbols = DecimalFormatSymbols.getInstance(getCurrentLocale());
 		if (symbols.getGroupingSeparator() == '\u202f') {
 			// change le séparateur de milliers en France par le séparateur de milliers d'avant Java 13,
-			// pour les rapports PDF qui ne comprennent pas \u202f (en iText 2.1.7 ou openpdf 1.3.30)
+			// pour les rapports PDF qui ne comprennent pas \u202f (en OpenPDF 1.3.33)
 			symbols.setGroupingSeparator('\u00a0');
 		}
 		return symbols;

--- a/javamelody-core/src/main/java/net/bull/javamelody/internal/model/Action.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/internal/model/Action.java
@@ -345,7 +345,7 @@ public enum Action {
 	private String mailTest(Collector collector, CollectorServer collectorServer) {
 		// note: a priori, inutile de traduire cela
 		if (!Parameters.isPdfEnabled()) {
-			throw new IllegalStateException("itext classes not found: add the itext dependency");
+			throw new IllegalStateException("openpdf classes not found: add the openpdf dependency");
 		}
 		if (Parameter.MAIL_SESSION.getValue() == null) {
 			throw new IllegalStateException(

--- a/javamelody-core/src/test/resources/pom.xml
+++ b/javamelody-core/src/test/resources/pom.xml
@@ -18,9 +18,9 @@
 			<version>${version}</version>
 		</dependency>
 		<dependency>
-			<groupId>com.lowagie</groupId>
-			<artifactId>itext</artifactId>
-			<version>2.1.7</version>
+			<groupId>com.github.librepdf</groupId>
+			<artifactId>openpdf</artifactId>
+			<version>1.3.33</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>bcmail-jdk14</artifactId>

--- a/javamelody-for-spring-boot/pom.xml
+++ b/javamelody-for-spring-boot/pom.xml
@@ -37,11 +37,11 @@
 			<version>${javamelody.version}</version>
 		</dependency>
 
-		<!-- Optional: openpdf (iText fork) dependency for PDF exports in JavaMelody -->
+		<!-- OpenPDF (iText fork) dependency for PDF exports in JavaMelody -->
 		<dependency>
 			<groupId>com.github.librepdf</groupId>
 			<artifactId>openpdf</artifactId>
-			<version>1.3.30</version>
+			<version>1.3.33</version>
 		</dependency>
 
 		<!-- Spring Boot Web Starter -->

--- a/javamelody-for-standalone/pom.xml
+++ b/javamelody-for-standalone/pom.xml
@@ -32,11 +32,11 @@
 			<artifactId>javamelody-core</artifactId>
 			<version>${javamelody.version}</version>
 		</dependency>
-		<!-- Optional: openpdf (iText fork) dependency for PDF exports in JavaMelody -->
+		<!-- OpenPDF (iText fork) dependency for PDF exports in JavaMelody -->
 		<dependency>
 			<groupId>com.github.librepdf</groupId>
 			<artifactId>openpdf</artifactId>
-			<version>1.3.30</version>
+			<version>1.3.33</version>
 		</dependency>
 	</dependencies>
 

--- a/javamelody-offline-viewer/pom.xml
+++ b/javamelody-offline-viewer/pom.xml
@@ -32,11 +32,11 @@
 			<artifactId>javamelody-core</artifactId>
 			<version>${javamelodyVersion}</version>
 		</dependency>
-		<!-- Optional: openpdf (iText fork) dependency for PDF exports in JavaMelody -->
+		<!-- OpenPDF (iText fork) dependency for PDF exports in JavaMelody -->
 		<dependency>
 			<groupId>com.github.librepdf</groupId>
 			<artifactId>openpdf</artifactId>
-			<version>1.3.30</version>
+			<version>1.3.33</version>
 		</dependency>
 	</dependencies>
 

--- a/javamelody-swing/pom.xml
+++ b/javamelody-swing/pom.xml
@@ -53,11 +53,11 @@
 			<artifactId>log4j-core</artifactId>
 			<version>2.20.0</version>
 		</dependency>
-		<!-- Dépendance iText pour exports PDF -->
+		<!-- Dépendance OpenPDF pour exports PDF -->
 		<dependency>
-			<groupId>com.lowagie</groupId>
-			<artifactId>itext</artifactId>
-			<version>2.1.7</version>
+			<groupId>com.github.librepdf</groupId>
+			<artifactId>openpdf</artifactId>
+			<version>1.3.33</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>bcmail-jdk14</artifactId>
@@ -75,9 +75,9 @@
 		</dependency>
 		<!-- Dépendance iText-RTF pour exports RTF -->
 		<dependency>
-			<groupId>com.lowagie</groupId>
-			<artifactId>itext-rtf</artifactId>
-			<version>2.1.7</version>
+			<groupId>com.github.librepdf</groupId>
+			<artifactId>openrtf</artifactId>
+			<version>1.2.1</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>bcmail-jdk14</artifactId>

--- a/javamelody-swing/src/main/java/net/bull/javamelody/swing/table/TablePopupMenu.java
+++ b/javamelody-swing/src/main/java/net/bull/javamelody/swing/table/TablePopupMenu.java
@@ -85,7 +85,7 @@ class TablePopupMenu extends JPopupMenu {
 		} catch (final ClassNotFoundException e) {
 			// l'export PDF ne sera pas disponible dans cette application
 			LoggerFactory.getLogger(TablePopupMenu.class)
-					.debug("Export PDF non disponible sans iText");
+					.debug("Export PDF non disponible sans OpenPDF");
 		}
 		try {
 			Class.forName("com.lowagie.text.rtf.RtfWriter2");


### PR DESCRIPTION
Update to OpenPDF 1.3.33. Release notes: https://github.com/LibrePDF/OpenPDF/releases/tag/1.3.33

Replace itext-rtf with OpenRTF. https://github.com/LibrePDF/OpenRTF 

Replace iText 2.1.7 with OpenPDF 1.3.33.  iText 2.1.7 was released in 2009 and has several security vulnerabilities.