### PR TITLE
Add optional IP address validation against IP ranges list

### DIFF
--- a/javamelody-core/src/main/java/net/bull/javamelody/Parameter.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/Parameter.java
@@ -222,6 +222,11 @@ public enum Parameter {
 	ALLOWED_ADDR_PATTERN("allowed-addr-pattern"),
 
 	/**
+	 * List of allowed IP addresses ranges, CIDR notation only.
+	 */
+	ALLOWED_ADDR_RANGE_LIST("allowed-addr-range-list"),
+
+	/**
 	 * List of authorized users for BASIC auth, when you do no want to use a realm and "security-constraint" in web.xml.<br/>
 	 * Format : user:password, one by line or separated by comma <br/>
 	 * <pre>

--- a/javamelody-core/src/main/java/net/bull/javamelody/internal/web/HttpAuth.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/internal/web/HttpAuth.java
@@ -95,7 +95,7 @@ public class HttpAuth {
 
 	public boolean isAllowed(HttpServletRequest httpRequest, HttpServletResponse httpResponse)
 			throws IOException {
-        if (!isRequestAllowed(httpRequest) || !isIPAddressAllowed(httpRequest)) {
+		if (!isRequestAllowed(httpRequest) || !isIPAddressAllowed(httpRequest)) {
 			LOG.debug("Forbidden access to monitoring from " + httpRequest.getRemoteAddr());
 			httpResponse.sendError(HttpServletResponse.SC_FORBIDDEN, "Forbidden access");
 			return false;

--- a/javamelody-core/src/test/java/net/bull/javamelody/internal/web/TestHttpAuth.java
+++ b/javamelody-core/src/test/java/net/bull/javamelody/internal/web/TestHttpAuth.java
@@ -44,6 +44,9 @@ public class TestHttpAuth {
 	private static final String USER_PWD = "user:pwd";
 	private static final String REMOTE_ADDR = "127.0.0.1"; // NOPMD
 
+	private static final String RANGE_KO = "192.168.1.0/24";
+	private static final String RANGE_OK = RANGE_KO + ";127.0.0.0/8";
+
 	/**
 	 * Initialisation.
 	 */
@@ -58,10 +61,26 @@ public class TestHttpAuth {
 	public void testIsAllowed() throws IOException {
 		assertTrue("no auth", isAllowed());
 		setProperty(Parameter.ALLOWED_ADDR_PATTERN, REMOTE_ADDR);
+		setProperty(Parameter.ALLOWED_ADDR_RANGE_LIST, null);
 		assertTrue("addr pattern", isAllowed());
 		setProperty(Parameter.ALLOWED_ADDR_PATTERN, "none");
 		assertFalse("addr pattern", isAllowed());
+
 		setProperty(Parameter.ALLOWED_ADDR_PATTERN, null);
+		setProperty(Parameter.ALLOWED_ADDR_RANGE_LIST, RANGE_KO);
+		assertFalse("allowed range", isAllowed());
+		setProperty(Parameter.ALLOWED_ADDR_RANGE_LIST, RANGE_OK);
+		assertTrue("allowed range", isAllowed());
+
+		setProperty(Parameter.ALLOWED_ADDR_RANGE_LIST, RANGE_KO);
+		setProperty(Parameter.ALLOWED_ADDR_PATTERN, REMOTE_ADDR);
+		assertFalse("allowed range", isAllowed());
+
+		setProperty(Parameter.ALLOWED_ADDR_RANGE_LIST, RANGE_OK);
+		assertTrue("allowed range", isAllowed());
+
+		setProperty(Parameter.ALLOWED_ADDR_PATTERN, null);
+		setProperty(Parameter.ALLOWED_ADDR_RANGE_LIST, null);
 		setProperty(Parameter.AUTHORIZED_USERS, USER_PWD);
 		assertFalse("authorized users", isAllowed(null));
 		assertFalse("authorized users", isAllowed("not BASIC"));


### PR DESCRIPTION
Hello,
This is a new feature that makes it possible to validate an IP address from a range list with CIDR notation (192.168.1.0/24 for example), in addition to the existing regex validation.
A client IP just need one of the two validations to be allowed to access monitoring page.
The range check is implemented in the code, but it can be made using [Apache Commons Net](https://commons.apache.org/proper/commons-net/apidocs/org/apache/commons/net/util/SubnetUtils.SubnetInfo.html#isInRange(java.lang.String)) if necessary. I did not use Apache methods because it adds >300kb library for a single method use.