### PR TITLE
Fix wrong version mongodb-driver-sync in javamelody-test-webapp

### DIFF
--- a/javamelody-test-webapp/pom.xml
+++ b/javamelody-test-webapp/pom.xml
@@ -200,7 +200,7 @@
 		<dependency>
 			<groupId>org.mongodb</groupId>
 			<artifactId>mongodb-driver-sync</artifactId>
-			<version>4.11.</version>
+			<version>4.11.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.inject</groupId>


### PR DESCRIPTION
As a result, module can't be built