### PR TITLE
JavaMelodyAutoConfiguration conditional on Servlet

### DIFF
--- a/javamelody-spring-boot-starter/src/main/java/net/bull/javamelody/JavaMelodyAutoConfiguration.java
+++ b/javamelody-spring-boot-starter/src/main/java/net/bull/javamelody/JavaMelodyAutoConfiguration.java
@@ -83,7 +83,7 @@ import jakarta.servlet.http.HttpServletResponse;
  */
 @Configuration
 @EnableConfigurationProperties(JavaMelodyConfigurationProperties.class)
-@ConditionalOnWebApplication
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
 @ConditionalOnProperty(prefix = JavaMelodyConfigurationProperties.PREFIX, name = "enabled", matchIfMissing = true)
 public class JavaMelodyAutoConfiguration {
 	/**


### PR DESCRIPTION
JavaMelodyAutoConfiguration only works for servlet type web applications so it should be conditional on that application type.

Without this conditional, attempts to run a reactive application with the JavaMelody classes present fails to start with:
```
org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'monitoringSessionListener' defined in class path resource [net/bull/javamelody/JavaMelodyAutoConfiguration.class]: Unsatisfied dependency expressed through method 'monitoringSessionListener' parameter 0: No qualifying bean of type 'jakarta.servlet.ServletContext' available: expected at least 1 bean which qualifies as autowire candidate.
```

With this conditional, the application starts (without JavaMelody, of course).