### PR TITLE
fixes #1214 remove column datlastsysoid from database query

### DIFF
--- a/javamelody-core/src/main/resources/net/bull/javamelody/resource/databaseInformations.properties
+++ b/javamelody-core/src/main/resources/net/bull/javamelody/resource/databaseInformations.properties
@@ -18,7 +18,7 @@ pg_size_pretty(pg_tablespace_size(spcname)) AS size, spcacl \
 FROM pg_tablespace ORDER BY spcname
 postgresql.pg_database = \
 SELECT datname, pg_get_userbyid(datdba) AS dba, pg_catalog.pg_encoding_to_char(encoding) AS encoding, \
-datistemplate, datallowconn, datconnlimit, datlastsysoid, datfrozenxid, spcname as tablespace, \
+datistemplate, datallowconn, datconnlimit, datfrozenxid, spcname as tablespace, \
 pg_size_pretty(pg_database_size(datname)) AS size, datacl \
 FROM pg_database, pg_tablespace WHERE dattablespace = pg_tablespace.oid ORDER BY datname
 # en commentaire, car pb_buffercache nécessite l'installation d'une contrib disponible avec postgresql,


### PR DESCRIPTION
Update the query to retrieve database information by removing the obsolete `datlastsysoid` column which is no longer supported in PostgreSQL 15