### PR TITLE
Introduce way to prevent writing the LastShutDown html file

### DIFF
--- a/javamelody-core/src/main/java/net/bull/javamelody/FilterContext.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/FilterContext.java
@@ -444,7 +444,10 @@ class FilterContext {
 		try {
 			try {
 				if (collector != null) {
-					new MonitoringController(collector, null).writeHtmlToLastShutdownFile();
+					String createShutDownFile = Parameter.CREATE_LAST_SHUTDOWN_FILE.getValue();
+					if (createShutDownFile == null || Boolean.parseBoolean(createShutDownFile)) {
+						new MonitoringController(collector, null).writeHtmlToLastShutdownFile();
+					}
 				}
 			} finally {
 				//on rebind les dataSources initiales à la place des proxy

--- a/javamelody-core/src/main/java/net/bull/javamelody/Parameter.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/Parameter.java
@@ -413,7 +413,12 @@ public enum Parameter {
 	/**
 	 * <a href='https://www.datadog.com/'>Datadog</a> host for accessing API. 'api.datadoghq.com' is default.
 	 */
-	DATADOG_API_HOST("datadog-api-host");
+	DATADOG_API_HOST("datadog-api-host"),
+
+	/**
+	 * If set to false no "last_shutdown.html" file is created when application is stopped
+	 */
+	CREATE_LAST_SHUTDOWN_FILE("create-last-shutdown-file");
 
 	private final String code;
 


### PR DESCRIPTION
In some systems (with a lot of threads) creating this file can take up to 5 seconds.
Since mostly this is not really important allow to disable creating the file...