### PR TITLE
Fix license naming to use the correct SPDX identifier.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ When submitting code, please follow existing [conventions and style](../../wiki/
 
 ## License
 
-By contributing your code, you agree to license your contribution under the terms of the [ASL](http://www.apache.org/licenses/LICENSE-2.0).
+By contributing your code, you agree to license your contribution under the terms of the [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0).
 
 All files are released with the Apache 2.0 license.
 

--- a/javamelody-collector-server/pom.xml
+++ b/javamelody-collector-server/pom.xml
@@ -12,7 +12,7 @@
 	<url>https://github.com/javamelody/javamelody/wiki</url>
 	<licenses>
 		<license>
-			<name>ASL</name>
+			<name>Apache-2.0</name>
 			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
 			<distribution>repo</distribution>
 		</license>

--- a/javamelody-core/src/main/java/net/bull/javamelody/Main.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/Main.java
@@ -44,7 +44,7 @@ import java.util.zip.ZipFile;
  * <tt>java -jar javamelody.war</tt>.
  *
  * @author Kohsuke Kawaguchi, extracted (and simplified) from Jenkins by Emeric Vernat
- * 	licence MIT (alias X11, donc compatible ASL)
+ * 	licence MIT (alias X11, donc compatible Apache-2.0)
  */
 @SuppressWarnings("all")
 public final class Main {

--- a/javamelody-core/src/site/apt/index.apt
+++ b/javamelody-core/src/site/apt/index.apt
@@ -12,7 +12,7 @@ Java Melody : monitoring of Java applications
 
 [screenshots/graphs_small.PNG]
 
-	License : {{{./license.html} ASL (opensource) }}
+	License : {{{./license.html} Apache-2.0 (opensource) }}
 
 	URL : https://github.com/javamelody/javamelody/wiki
 
@@ -23,7 +23,7 @@ Java Melody : monitoring of Java applications
 	it is a tool to measure and calculate statistics on real operation of an application
 	depending on the usage of the application by users.
 	
-	JavaMelody is opensource (ASL) and production ready: in production in an application of 25 person years.
+	JavaMelody is opensource (Apache-2.0) and production ready: in production in an application of 25 person years.
 	JavaMelody is easy to integrate in most applications and is lightweight (no profiling and no database).
 
 	JavaMelody is mainly based on statistics of requests and on evolution charts.

--- a/javamelody-core/src/site/apt/index_fr.apt
+++ b/javamelody-core/src/site/apt/index_fr.apt
@@ -12,7 +12,7 @@ Java Melody : monitoring d'applications Java
 
 [screenshots/graphs_small.PNG]
 
-	Licence : {{{./license.html} ASL (opensource) }}
+	Licence : {{{./license.html} Apache-2.0 (opensource) }}
 	
 	URL : https://github.com/javamelody/javamelody/wiki
 	
@@ -23,7 +23,7 @@ Java Melody : monitoring d'applications Java
 	c'est un outil de mesure et de statistiques sur le fonctionnement réel d'une application
 	selon l'usage qui en est fait par les utilisateurs.
 	
-	JavaMelody est opensource (ASL) et prêt pour une mise en production : déjà en production dans une application de 25 années hommes.
+	JavaMelody est opensource (Apache-2.0) et prêt pour une mise en production : déjà en production dans une application de 25 années hommes.
 	JavaMelody est facile à intégrer dans la plupart des applications et est léger (pas de profileur et pas de base de données).
 
 	JavaMelody est en grande partie basé sur des statistiques de requêtes et sur des courbes d'évolution.

--- a/javamelody-spring-boot-starter/README.md
+++ b/javamelody-spring-boot-starter/README.md
@@ -4,7 +4,7 @@ The JavaMelody Spring Boot Starter facilitates the integration of JavaMelody in 
 
 For Spring Boot 4, see [JavaMelody Spring Boot 4 Starter](../javamelody-spring-boot4-starter).
 
-License ASL, http://www.apache.org/licenses/LICENSE-2.0
+License Apache-2.0, http://www.apache.org/licenses/LICENSE-2.0
 
 ## Integration
 

--- a/javamelody-spring-boot-starter/pom.xml
+++ b/javamelody-spring-boot-starter/pom.xml
@@ -16,7 +16,7 @@
 
 	<licenses>
 		<license>
-			<name>ASL</name>
+			<name>Apache-2.0</name>
 			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
 			<distribution>repo</distribution>
 		</license>

--- a/javamelody-spring-boot4-starter/README.md
+++ b/javamelody-spring-boot4-starter/README.md
@@ -4,7 +4,7 @@ The JavaMelody Spring Boot 4 Starter facilitates the integration of JavaMelody i
 
 For Spring Boot 3, see [JavaMelody Spring Boot Starter](../javamelody-spring-boot-starter).
 
-License ASL, http://www.apache.org/licenses/LICENSE-2.0
+License Apache-2.0, http://www.apache.org/licenses/LICENSE-2.0
 
 ## Integration
 

--- a/javamelody-spring-boot4-starter/pom.xml
+++ b/javamelody-spring-boot4-starter/pom.xml
@@ -16,7 +16,7 @@
 
 	<licenses>
 		<license>
-			<name>ASL</name>
+			<name>Apache-2.0</name>
 			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
 			<distribution>repo</distribution>
 		</license>

--- a/javamelody-swing/pom.xml
+++ b/javamelody-swing/pom.xml
@@ -15,7 +15,7 @@
 	<url>https://github.com/javamelody/javamelody/wiki</url>
 	<licenses>
 		<license>
-			<name>ASL</name>
+			<name>Apache-2.0</name>
 			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
 			<distribution>repo</distribution>
 		</license>

--- a/javamelody-swing/src/site/apt/index.apt
+++ b/javamelody-swing/src/site/apt/index.apt
@@ -10,6 +10,6 @@
 
 Java Melody Swing : alternative UI with Swing for Java Melody
 
-	License : {{{./license.html} ASL (opensource) }}
+	License : {{{./license.html} Apache-2.0 (opensource) }}
 
 	URL : https://github.com/javamelody/javamelody/wiki


### PR DESCRIPTION
I have run into an issue with automated license detection where the license is detected as ASL as stated in a few pom.xml's even though the library is really licensed as Apache License 2.0.

This PR replaces the license identifiers (ASL) with the correct SPDX identifier (Apache-2.0). 