### PR TITLE
Fall back to MANIFEST.MF when a dependency jar has no embedded pom.xml

### DIFF
--- a/javamelody-core/src/main/java/net/bull/javamelody/internal/model/MavenArtifact.java
+++ b/javamelody-core/src/main/java/net/bull/javamelody/internal/model/MavenArtifact.java
@@ -36,6 +36,8 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -43,6 +45,7 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
+import org.jspecify.annotations.Nullable;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -89,6 +92,20 @@ public final class MavenArtifact implements Serializable {
 	}
 
 	private static MavenArtifact parseDependency(URL jarFileLocation) throws IOException {
+		final MavenArtifact dependency = parseDependencyFromMavenPom(jarFileLocation);
+
+		if (dependency != null) {
+			return dependency;
+		}
+
+		// certains artifacts (par exemple Spring Framework/Boot depuis leur passage à Gradle,
+		// ou le driver JDBC PostgreSQL) n'embarquent pas de META-INF/maven/.../pom.xml dans leur jar ;
+		// on se rabat alors sur leur META-INF/MANIFEST.MF, lisible sans accès à un dépôt Maven
+		return parseDependencyFromManifest(jarFileLocation);
+	}
+
+	@Nullable
+	private static MavenArtifact parseDependencyFromMavenPom(final URL jarFileLocation) throws IOException {
 		final byte[] pomXml = readMavenFileFromJarFile(jarFileLocation, "pom.xml");
 		if (pomXml != null) {
 			final MavenArtifact dependency = new MavenArtifact();
@@ -96,6 +113,44 @@ public final class MavenArtifact implements Serializable {
 			return dependency;
 		}
 		return null;
+	}
+
+	private static MavenArtifact parseDependencyFromManifest(URL jarFileLocation) throws IOException {
+		final byte[] manifestFile = readJarFileEntry(jarFileLocation, "META-INF/MANIFEST.MF");
+		if (manifestFile == null) {
+			return null;
+		}
+		final Attributes attributes = new Manifest(new ByteArrayInputStream(manifestFile))
+				.getMainAttributes();
+		final String version = attributes.getValue("Implementation-Version");
+		if (version == null) {
+			return null;
+		}
+		final MavenArtifact dependency = new MavenArtifact();
+		dependency.version = version;
+		dependency.artifactId = getArtifactIdFromFileName(jarFileLocation, version);
+		final String vendorId = attributes.getValue("Implementation-Vendor-Id");
+		dependency.groupId = vendorId != null ? vendorId : "";
+		dependency.name = attributes.getValue("Implementation-Title");
+		dependency.updated = true;
+		return dependency;
+	}
+
+	private static String getArtifactIdFromFileName(URL jarFileLocation, String version) {
+		String fileName = jarFileLocation.getFile();
+		if (fileName.endsWith("!/")) {
+			// cas d'un jar imbriqué dans un jar exécutable, par exemple avec Spring Boot
+			fileName = fileName.substring(0, fileName.length() - "!/".length());
+		}
+		fileName = fileName.substring(fileName.lastIndexOf('/') + 1);
+		if (fileName.endsWith(".jar")) {
+			fileName = fileName.substring(0, fileName.length() - ".jar".length());
+		}
+		final String versionSuffix = '-' + version;
+		if (fileName.endsWith(versionSuffix)) {
+			fileName = fileName.substring(0, fileName.length() - versionSuffix.length());
+		}
+		return fileName;
 	}
 
 	private void parsePomXml(InputStream pomXml) throws IOException {
@@ -665,6 +720,21 @@ public final class MavenArtifact implements Serializable {
 			while (entry != null) {
 				if (entry.getName().startsWith("META-INF/maven/")
 						&& entry.getName().endsWith("/" + pomFileName)) {
+					return InputOutput.pumpToByteArray(zipInputStream);
+				}
+				zipInputStream.closeEntry();
+				entry = zipInputStream.getNextEntry();
+			}
+		}
+		return null;
+	}
+
+	private static byte[] readJarFileEntry(URL jarFileLocation, String entryName) throws IOException {
+		try (ZipInputStream zipInputStream = new ZipInputStream(
+				new BufferedInputStream(jarFileLocation.openStream(), 4096))) {
+			ZipEntry entry = zipInputStream.getNextEntry();
+			while (entry != null) {
+				if (entryName.equals(entry.getName())) {
 					return InputOutput.pumpToByteArray(zipInputStream);
 				}
 				zipInputStream.closeEntry();

--- a/javamelody-core/src/test/java/net/bull/javamelody/internal/model/TestMavenArtifact.java
+++ b/javamelody-core/src/test/java/net/bull/javamelody/internal/model/TestMavenArtifact.java
@@ -21,23 +21,30 @@ import static org.easymock.EasyMock.createNiceMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+import java.util.zip.ZipEntry;
 
 import org.easymock.IAnswer;
 import org.jrobin.graph.RrdGraph;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import jakarta.servlet.ServletContext;
 import net.bull.javamelody.Parameter;
@@ -49,6 +56,7 @@ import net.bull.javamelody.internal.common.Parameters;
  * @author Emeric Vernat
  */
 class TestMavenArtifact {
+
 	private static final String MAVEN_CENTRAL = "https://repo1.maven.org/maven2";
 
 	private static final File LOCAL_REPO = new File(
@@ -131,4 +139,55 @@ class TestMavenArtifact {
 			}
 		}
 	}
+
+	/**
+	 * Test for artifacts without embedded META-INF/maven/.../pom.xml (for example Spring
+	 * Framework/Boot since their move to Gradle, or the PostgreSQL JDBC driver), whose version
+	 * must be read from META-INF/MANIFEST.MF instead.
+	 * @param tempDir dossier temporaire fourni et nettoyé par JUnit
+	 * @throws IOException e
+	 */
+	@Test
+	void testGetWebappDependenciesFromManifest(@TempDir File tempDir) throws IOException {
+		final String jarFileName = "no-pom-example-1.2.3.jar";
+		final File jarFile = createJarWithManifestOnly(tempDir, jarFileName, "1.2.3", "org.example",
+				"No Pom Example");
+
+		final ServletContext context = createNiceMock(ServletContext.class);
+		final Set<String> dependencies = Collections.singleton("/WEB-INF/lib/" + jarFileName);
+		expect(context.getResourcePaths("/WEB-INF/lib/")).andReturn(dependencies).anyTimes();
+		expect(context.getResource("/WEB-INF/lib/" + jarFileName)).andReturn(jarFile.toURI().toURL())
+		                                                           .anyTimes();
+		expect(context.getMajorVersion()).andReturn(5).anyTimes();
+		expect(context.getMinorVersion()).andReturn(0).anyTimes();
+		replay(context);
+		Parameters.initialize(context);
+		final Map<String, MavenArtifact> webappDependencies = MavenArtifact.getWebappDependencies();
+		verify(context);
+
+		MavenArtifact dependency = webappDependencies.get(jarFileName);
+		assertNotNull(dependency, "dependency resolved from manifest");
+		assertEquals("1.2.3", dependency.getVersion(), "version");
+		assertEquals("no-pom-example", dependency.getArtifactId(), "artifactId");
+		assertEquals("org.example", dependency.getGroupId(), "groupId");
+	}
+
+	private static File createJarWithManifestOnly(File directory, String fileName, String version,
+			String vendorId, String title) throws IOException {
+		final File jarFile = new File(directory, fileName);
+		final Manifest manifest = new Manifest();
+		manifest.getMainAttributes().putValue("Manifest-Version", "1.0");
+		manifest.getMainAttributes().putValue("Implementation-Version", version);
+		manifest.getMainAttributes().putValue("Implementation-Vendor-Id", vendorId);
+		manifest.getMainAttributes().putValue("Implementation-Title", title);
+		try (JarOutputStream jarOutputStream = new JarOutputStream(new FileOutputStream(jarFile),
+				manifest)) {
+			jarOutputStream.putNextEntry(new ZipEntry("README.txt"));
+			jarOutputStream.write(("This jar is only a test fixture: it intentionally has no files, in order to test "
+								   + "the fallback of MavenArtifact to META-INF/MANIFEST.MF.").getBytes(StandardCharsets.UTF_8));
+			jarOutputStream.closeEntry();
+		}
+		return jarFile;
+	}
+
 }


### PR DESCRIPTION
If Gradle is used to build a jar than there is no `pom.xml` embedded. For those artifacts, `MavenArtifact.parseDependency`
returned `null`, so the dependencies report showed no name/group/version at all, even though every such jar still carries the version (and often the groupId via `Implementation-Vendor-Id`) in its own `META-INF/MANIFEST.MF`.

Resolving these versions via the POM's parent/BOM chain instead would require fetching remote parent POMs through maven-repositories, which is not an option for deployments that disable outside repository access. Reading the manifest
that already ships inside the jar needs no repository access at all, so it works regardless of that setting.

fixes #1310 

Disclaimer: Fix was written with the help of Claude Code (AI) but reviewed and finally adapted by human.